### PR TITLE
Fix some rubocop warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rubocop'
 gem 'rubocop-rails'
 
-gem 'haml-rails', "~> 2.0"
+gem 'haml-rails', '~> 2.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,3 @@
 class HomeController < ApplicationController
-
-  def index
-  end
-
+  def index; end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
 Rails.application.routes.draw do
-
   root 'home#index'
-
 end


### PR DESCRIPTION

The last PR created some rubocop errors, but I can't get mad, seeing as rubocop hadn't been added yet when you created your branch :-)