### PR TITLE
(Fix) Terraform naming

### DIFF
--- a/ecs-service.tf
+++ b/ecs-service.tf
@@ -50,9 +50,9 @@ resource "aws_iam_role_policy" "task_role_policy" {
 module "ecs-service" {
   source = "./vendor/terraform_modules/terraform-aws-ecs-service"
 
-  environment = "ahm"
+  environment = "app"
 
-  service_name          = "${var.environment}"
+  service_name          = "${local.app_name}-${var.environment}"
   service_desired_count = 1
 
   vpc_id   = "${data.aws_vpc.vpc.id}"

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   app_name                   = "ahm"
   infrastructure_domain_name = "${var.infrastructure_name}.${var.environment}.${local.shared_infrastructure_name}.${var.root_domain_zone}"
-  app_domain_name            = "affordable-housing-monitoring.${local.infrastructure_domain_name}"
+  app_domain_name            = "app.${local.infrastructure_domain_name}"
   app_service_name           = "${local.app_name}-${var.environment}"
   app_github_owner           = "dxw"
   app_github_repo            = "affordable-housing-monitoring"


### PR DESCRIPTION
* The url was too long, so used the `ahm` abbreviation
* Used `app` in places where there were duplicate `ahm` in names