### PR TITLE
(fix) correct heading hierarchy

### DIFF
--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -1,7 +1,9 @@
 .govuk-width-container
 
+  %h1.govuk-heading-xl= t('developments.index_heading')
+
   %table.govuk-table
-    %caption.govuk-table__caption.govuk-heading-xl= t('developments.index_heading')
+    %caption.govuk-table__caption.govuk-visually-hidden= t('developments.index_heading')
     %thead.govuk-table__head
       %tr.govuk-table__row
         %th{class: "govuk-table__header", scope: "col"}= t('developments.application_number')


### PR DESCRIPTION
The index page was using a `<caption>` element for the page heading; it's been replaced with an `<h1>`.