### PR TITLE
(Fix) Add SECRET_KEY_BASE in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY . $APP_PATH
 RUN yarn install
 
 # compile assets for production
-RUN bundle exec rake assets:precompile
+RUN SECRET_KEY_BASE=dummy bundle exec rake assets:precompile
 
 # make app own the project files
 RUN chown -R app:app $APP_PATH


### PR DESCRIPTION
* This version of Rails requires SECRET_KEY_BASE set. We can just set it
to 'dummy' to allow it to run
* https://github.com/rails/rails/issues/32947