### PR TITLE
Set production logging to STDOUT

### DIFF
--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -80,11 +80,9 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
For DXW hosting, we want logs to go to STDOUT, without having to set this ENV variable.

Staging environment also loads this file, so changes apply there.