### PR TITLE
(Chore) Run docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,17 +5,24 @@ echo "Starting docker entrypoint…"
 
 setup_database()
 {
-  echo "Checking database setup is up-to-date…"
+  echo "ENTRYPOINT: Checking database setup is up to date…"
   # Rails will throw an error if no database exists"
   #   PG::ConnectionBad: FATAL:  database "affordable_housing_monitoring_development" does not exist
   if rake db:migrate:status &> /dev/null; then
-    echo "Database found, running db:migrate…"
+    echo "ENTRYPOINT: Database found, running db:migrate…"
     rake db:migrate
   else
-    echo "No database found, running db:create db:schema:load…"
-    rake db:create db:schema:load
+    echo "ENTRYPOINT: No database found…"
+
+    if [ "$RAILS_ENV" == "production" ]; then
+      echo "ENTRYPOINT: Environment is production, doing nothing."
+    else
+      echo "ENTRYPOINT: Environment is in non-production, attempting to automatically create the database…"
+      echo "ENTRYPOINT: Running db:create db:schema:load…"
+      rake db:create db:schema:load
+    fi
   fi
-  echo "Finished database setup"
+  echo "ENTRYPOINT: Finished database setup."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "app_github_token" {
 variable "container_command" {
   description = "command to run in container"
   type        = "list"
-  default     = ["bundle", "exec", "puma"]
+  default     = ["/docker-entrypoint.sh", "bundle", "exec", "puma"]
 }
 
 variable "additional_domains" {


### PR DESCRIPTION
* Also ensures that `db:create` is not ran in production - this needs to
be ran manually at first launch