### PR TITLE
(fix) adds an underline to the logout link

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -6,4 +6,5 @@
 	font: inherit;
 	cursor: pointer;
 	outline: inherit;
+  text-decoration: underline;
 }


### PR DESCRIPTION
<img width="742" alt="Screenshot 2019-10-16 at 15 52 50" src="https://user-images.githubusercontent.com/822507/66930787-06cfff80-f02d-11e9-82b3-75a635b3fd35.png">
