### PR TITLE
add simple_form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'rubocop'
 gem 'rubocop-rails'
 
 gem 'haml-rails', '~> 2.0'
+gem 'simple_form', '4.1.0'
 
 gem 'devise'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,9 @@ GEM
       childprocess (>= 0.5, < 3.0)
       rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
+    simple_form (4.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -287,6 +290,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5)
   selenium-webdriver
+  simple_form (= 4.1.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/views/developments/_form.html.haml
+++ b/app/views/developments/_form.html.haml
@@ -1,11 +1,8 @@
 .govuk-form-group
-  = f.label :application_number
-  = f.text_field :application_number
+  = f.input :application_number, input_html: { class: "govuk-input govuk-input--width-10" }
 
 .govuk-form-group
-  = f.label :site_address
-  = f.text_field :site_address
+  = f.input :site_address
 
 .govuk-form-group
-  = f.label :proposal
-  = f.text_field :proposal
+  = f.input :proposal

--- a/app/views/developments/_form.html.haml
+++ b/app/views/developments/_form.html.haml
@@ -1,11 +1,11 @@
 .govuk-form-group
-  = f.label :application_number, class: "govuk-label"
-  = f.text_field :application_number, class: "govuk-input govuk-input--width-20"
+  = f.label :application_number
+  = f.text_field :application_number
 
 .govuk-form-group
-  = f.label :site_address, class: "govuk-label"
-  = f.text_field :site_address, class: "govuk-input govuk-input--width-20"
+  = f.label :site_address
+  = f.text_field :site_address
 
 .govuk-form-group
-  = f.label :proposal, class: "govuk-label"
-  = f.text_field :proposal, class: "govuk-input govuk-input--width-20"
+  = f.label :proposal
+  = f.text_field :proposal

--- a/app/views/developments/edit.html.haml
+++ b/app/views/developments/edit.html.haml
@@ -2,14 +2,14 @@
 
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
-  
+
   .govuk-grid-row
     .govuk-grid-column-full
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading Edit details of development
 
-        = form_for @development do |f|
+        = simple_form_for @development do |f|
           = render partial: 'form', locals: {f: f}
           .govuk-form-group
             = f.submit t('buttons.submit'), class: "govuk-button govuk-!-margin-right-1"

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -7,7 +7,7 @@
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading= t('developments.new_heading')
 
-        = form_for @development do |f|
+        = simple_form_for @development do |f|
           = render partial: 'form', locals: {f: f}
           .govuk-form-group
             = f.submit t('buttons.submit'), class: "govuk-button govuk-!-margin-right-1"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,22 +7,21 @@
   .govuk-grid-row
     .govuk-grid-column-full
 
-      = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+
+        = f.error :email
+
+        = f.error_notification
+
         .govuk-form-group
-          = f.label :email, class: "govuk-label"
-          = f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input govuk-input--width-20"
+          = f.input :email, required: true, input_html: { class: "govuk-input govuk-input--width-20" }
         .govuk-form-group
-          = f.label :password, class: "govuk-label"
-          = f.password_field :password, autocomplete: "current-password", class: "govuk-input govuk-input--width-20"
+          = f.input :password, label: 'Password', required: true, input_html: { class: "govuk-input govuk-input--width-20" }
 
         - if devise_mapping.rememberable?
           .govuk-form-group
             .govuk-checkboxes
-              .govuk-checkboxes__item
-                = f.check_box :remember_me, class: "govuk-checkboxes__input", name: "remember_me", type: "checkbox", value: "remember_me"
-                = f.label :remember_me, for: "remember_me", class: "govuk-label govuk-checkboxes__label"
+              = f.input :remember_me, wrapper: :inline_checkbox
 
         .actions
           = f.submit "Log in", class: "govuk-button", "data-module": "govuk-button"
-
-      -# = render "devise/shared/links"

--- a/app/views/dwellings/_fields.html.haml
+++ b/app/views/dwellings/_fields.html.haml
@@ -1,11 +1,6 @@
-- @dwelling.errors.full_messages.each do |msg|
-  = msg
 .govuk-form-group
-  = form.label :tenure, class: "govuk-label"
-  = form.select :tenure, Dwelling::TENURES, {}, { class: "govuk-select" }
+  = form.input :tenure, collection: Dwelling::TENURES, wrapper: :select
 .govuk-form-group
-  = form.label :habitable_rooms, 'Number of habitable rooms', class: "govuk-label"
-  = form.number_field :habitable_rooms, class: "govuk-input govuk-input--width-2"
+  = form.input :habitable_rooms, input_html: { class: "govuk-input govuk-input--width-2" }, label: 'Number of habitable rooms'
 .govuk-form-group
-  = form.label :bedrooms, 'Number of bedrooms', class: "govuk-label"
-  = form.number_field :bedrooms, class: "govuk-input govuk-input--width-2"
+  = form.input :bedrooms, input_html: { class: "govuk-input govuk-input--width-2" }, label: 'Number of bedrooms'

--- a/app/views/dwellings/edit.html.haml
+++ b/app/views/dwellings/edit.html.haml
@@ -5,7 +5,7 @@
     .govuk-grid-column-full
       %h1.govuk-heading-xl Edit dwelling
 
-      = form_for([@development, @dwelling]) do |form|
+      = simple_form_for([@development, @dwelling]) do |form|
         = render partial: 'fields', locals: { form: form }
         = form.submit 'Save dwelling', class: "govuk-button"
 

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -1,5 +1,16 @@
+- content_for(:page_title) { t("page_title_prefix") + "Dwellings for development " + @development.application_number }
+
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
+
+  - if @dwelling.errors.any?
+    .govuk-error-summary{"aria-labelledby" => "error-summary-title", "data-module" => "govuk-error-summary", :role => "alert", :tabindex => "-1"}
+      %h2#error-summary-title.govuk-error-summary__title
+        There is a problem
+      .govuk-error-summary__body
+        %ul.govuk-list.govuk-error-summary__list
+          - @dwelling.errors.each do |attribute, error|
+            %li= link_to @dwelling.errors.full_message(attribute, error), "#dwelling_#{attribute}"
 
   .govuk-grid-row
     .govuk-grid-column-full
@@ -31,6 +42,6 @@
 
       %h2.govuk-heading-l{class: "govuk-!-margin-top-5"} Add a dwelling
 
-      = form_for([@development, @dwelling]) do |form|
+      = simple_form_for([@development, @dwelling]) do |form|
         = render partial: 'fields', locals: { form: form }
         = form.submit 'Add dwelling', class: "govuk-button"

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,62 @@
+require Rails.root.join('lib', 'simple_form', 'optional_labels')
+
+SimpleForm::Components::Labels.prepend SimpleForm::Components::OptionalLabels
+SimpleForm::Components::Labels::ClassMethods.include SimpleForm::Components::OptionalLabels::ClassMethods
+
+SimpleForm.setup do |config|
+  config.wrappers :default, tag: 'div',
+                            class: 'govuk-form-group', error_class: 'govuk-form-group--error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label, class: 'govuk-label'
+    b.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
+    b.use :hint, wrap_with: { tag: 'span', class: 'govuk-hint' }
+    b.use :input, class: 'govuk-input', error_class: 'govuk-input--error'
+  end
+
+  config.wrappers :select, tag: 'div', class: 'govuk-form-group', error_class: 'govuk-form-group--error' do |field|
+    field.use :label, wrap_with: { tag: 'span', class: 'govuk-label govuk-label' }
+    field.use :hint, wrap_with: { tag: 'div', class: 'govuk-hint' }
+    field.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
+    field.use :input, as: :select, class: 'govuk-select'
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :inline
+
+  # Default class for buttons
+  config.button_class = 'govuk-button'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Whether attributes are required by default (or not). Default is true.
+  config.required_by_default = false
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Append 'optional' label instead of prepending
+  config.label_text = ->(label, optional, _explicit_label) { "#{label}<span class=\"govuk-hint\">#{optional}</span>" }
+end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -14,13 +14,6 @@ SimpleForm.setup do |config|
     b.use :input, class: 'govuk-input', error_class: 'govuk-input--error'
   end
 
-  config.wrappers :select, tag: 'div', class: 'govuk-form-group', error_class: 'govuk-form-group--error' do |field|
-    field.use :label, wrap_with: { tag: 'span', class: 'govuk-label govuk-label' }
-    field.use :hint, wrap_with: { tag: 'div', class: 'govuk-hint' }
-    field.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
-    field.use :input, as: :select, class: 'govuk-select'
-  end
-
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default
 
@@ -59,4 +52,28 @@ SimpleForm.setup do |config|
 
   # Append 'optional' label instead of prepending
   config.label_text = ->(label, optional, _explicit_label) { "#{label}<span class=\"govuk-hint\">#{optional}</span>" }
+end
+
+# Bespoke wrappers
+
+SimpleForm.setup do |config|
+  config.wrappers :select, tag: 'div', class: 'govuk-form-group', error_class: 'govuk-form-group--error' do |field|
+    field.use :label, wrap_with: { tag: 'span', class: 'govuk-label govuk-label' }
+    field.use :hint, wrap_with: { tag: 'div', class: 'govuk-hint' }
+    field.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
+    field.use :input, as: :select, class: 'govuk-select'
+  end
+
+  config.wrappers :inline_checkbox, tag: 'div',
+                                    class: 'govuk-form-group',
+                                    error_class: 'govuk-form-group--error' do |checkbox|
+    checkbox.use :html5
+    checkbox.wrapper class: 'govuk-checkboxes__item' do |field|
+      field.use :input, class: 'govuk-checkboxes__input'
+      field.use :label_text, wrap_with: { tag: 'label', class: 'govuk-label govuk-label govuk-checkboxes__label' }
+      field.optional :hint, wrap_with: { tag: 'div', class: 'govuk-hint' }
+    end
+
+    checkbox.use :error, wrap_with: { tag: 'div', class: 'help-inline' }
+  end
 end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_114156) do
+ActiveRecord::Schema.define(version: 2019_10_14_135208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_114156) do
     t.text "proposal"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "state", default: "draft", null: false
   end
 
   create_table "dwellings", force: :cascade do |t|

--- a/lib/simple_form/optional_labels.rb
+++ b/lib/simple_form/optional_labels.rb
@@ -1,0 +1,28 @@
+module SimpleForm
+  module Components
+    module OptionalLabels
+      module ClassMethods
+        def translate_optional_html
+          i18n_cache :translate_optional_html do
+            I18n.t(
+              :"simple_form.optional.html",
+              default: translate_optional_text
+            )
+          end
+        end
+
+        def translate_optional_text
+          I18n.t(:"simple_form.optional.text", default: 'This value is optional')
+        end
+      end
+
+      protected
+
+      def required_label_text #:nodoc:
+        return if required_field?
+
+        self.class.translate_optional_html.dup
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR: 

- adds the `simple_form` gem
- uses it to build the 'dwellings' form
- applies GOV.UK styles via a custom wrapper
- follows GOV.UK patterns for error reporting (i.e. both inline and top-of-page summary)

<img width="741" alt="Screenshot 2019-10-21 at 16 13 54" src="https://user-images.githubusercontent.com/822507/67218315-1761ea80-f41e-11e9-80e8-f49a82538551.png">
