### PR TITLE
page titles are better for accessibility

### DIFF
--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -1,0 +1,9 @@
+module PageTitleHelper
+  def page_title(title = '')
+    if title.present?
+      title + " - #{I18n.t('page_title_suffix')}"
+    else
+      I18n.t('page_title_suffix')
+    end
+  end
+end

--- a/app/views/developments/edit.html.haml
+++ b/app/views/developments/edit.html.haml
@@ -1,8 +1,8 @@
-- content_for(:page_title) { t("page_title_prefix") + "edit development #{@development.application_number}" }
+- content_for(:page_title) { page_title("edit development #{@development.application_number}") }
 
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
-  
+
   .govuk-grid-row
     .govuk-grid-column-full
       %fieldset.govuk-fieldset

--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -1,4 +1,4 @@
-- content_for(:page_title) { t("page_title_prefix") + "all developments" }
+- content_for(:page_title) { page_title('All developments') }
 
 .govuk-width-container
 

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -1,4 +1,4 @@
-- content_for(:page_title) { t("page_title_prefix") + "add a new development" }
+- content_for(:page_title) { page_title('Add a new development') }
 
 .govuk-width-container
   .govuk-grid-row

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -1,4 +1,4 @@
-- content_for(:page_title) { t("page_title_prefix") + "development " + @development.application_number }
+- content_for(:page_title) { page_title("Development " + @development.application_number) }
 
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,4 @@
-- content_for(:page_title) { t("page_title_prefix") + "log in" }
+- content_for(:page_title) { page_title('Log in') }
 
 .govuk-width-container
 

--- a/app/views/dwellings/edit.html.haml
+++ b/app/views/dwellings/edit.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { page_title('Edit dwelling') }
+
 .govuk-width-container
   = link_to "Back", development_dwellings_path(@development), class: "govuk-back-link"
 

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:page_title) { page_title("Dwellings for " + @development.application_number) }
+
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  page_title_prefix: "Southwark Affordable Homes Monitoring - "
+  page_title_suffix: "Southwark Affordable Homes Monitoring"
   service_name: "Affordable homes monitoring"
   navigation:
     developments: "View all developments"

--- a/spec/helpers/page_title_helper_spec.rb
+++ b/spec/helpers/page_title_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe PageTitleHelper, type: :helper do
+  describe 'page_title' do
+    context 'when no page title is passed' do
+      it 'renders the default page title' do
+        expect(helper.page_title).to eq 'Southwark Affordable Homes Monitoring'
+      end
+    end
+
+    context 'when a page title is passed' do
+      it 'renders the page title followed by the default page title' do
+        title = 'All developments'
+        expect(helper.page_title(title)).to eq 'All developments - Southwark Affordable Homes Monitoring'
+      end
+    end
+  end
+end


### PR DESCRIPTION
this PR:

- adds a helper and spec for creating page titles
- uses the more specific fragment of the page title before the generic fragment (better for screen readers)