### PR TITLE
Feature/development states

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'haml-rails', '~> 2.0'
 
 gem 'devise'
 
+gem 'aasm'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (6.0.0)
       actionpack (= 6.0.0)
       nio4r (~> 2.0)
@@ -271,6 +273,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -39,6 +39,17 @@ class DevelopmentsController < ApplicationController
     redirect_to development_path(@development)
   end
 
+  def start_confirmation
+    @development = Development.find(params[:id])
+  end
+
+  def start
+    @development = Development.find(params[:id])
+    @development.start!
+    flash[:notice] = 'Development marked as started'
+    redirect_to development_path(@development)
+  end
+
   private
 
   def development_params

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -28,6 +28,17 @@ class DevelopmentsController < ApplicationController
     redirect_to action: :index
   end
 
+  def agree_confirmation
+    @development = Development.find(params[:id])
+  end
+
+  def agree
+    @development = Development.find(params[:id])
+    @development.agree!
+    flash[:notice] = 'Development marked as agreed'
+    redirect_to development_path(@development)
+  end
+
   private
 
   def development_params

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -50,6 +50,17 @@ class DevelopmentsController < ApplicationController
     redirect_to development_path(@development)
   end
 
+  def complete_confirmation
+    @development = Development.find(params[:id])
+  end
+
+  def complete
+    @development = Development.find(params[:id])
+    @development.complete!
+    flash[:notice] = 'Development marked as completed'
+    redirect_to development_path(@development)
+  end
+
   private
 
   def development_params

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -1,3 +1,23 @@
 class Development < ApplicationRecord
   has_many :dwellings, dependent: :destroy
+
+  validates :state, presence: true
+
+  include AASM
+  aasm column: 'state' do
+    state :draft, initial: true
+    state :agreed, :started, :completed
+
+    event :agree do
+      transitions from: :draft, to: :agreed
+    end
+
+    event :start do
+      transitions from: :agreed, to: :started
+    end
+
+    event :complete do
+      transitions from: :started, to: :completed
+    end
+  end
 end

--- a/app/views/developments/agree_confirmation.html.haml
+++ b/app/views/developments/agree_confirmation.html.haml
@@ -1,0 +1,4 @@
+%p Once you agree, any changes will require an audit log
+
+= form_for @development, url: agree_development_path(@development) do |form|
+  = form.submit 'Mark as agreed'

--- a/app/views/developments/agree_confirmation.html.haml
+++ b/app/views/developments/agree_confirmation.html.haml
@@ -1,4 +1,16 @@
-%p Once you agree, any changes will require an audit log
+- content_for(:page_title) { "Mark development #{@development.application_number} as agreed – " + t("page_title_prefix") }
 
-= form_for @development, url: agree_development_path(@development) do |form|
-  = form.submit 'Mark as agreed'
+.govuk-width-container
+  = link_to "Back", developments_path, class: "govuk-back-link"
+  .govuk-grid-row
+    .govuk-grid-column-full-from-desktop
+      %h1.govuk-heading-l Mark development #{@development.application_number} as agreed
+
+      .govuk-warning-text
+        %span.govuk-warning-text__icon{"aria-hidden" => "true"} !
+        %strong.govuk-warning-text__text
+          %span.govuk-warning-text__assistive Warning
+          Once you agree, any changes will require an audit log.
+
+      = form_for @development, url: agree_development_path(@development) do |form|
+        = form.submit 'Mark as agreed', class: "govuk-button"

--- a/app/views/developments/complete_confirmation.html.haml
+++ b/app/views/developments/complete_confirmation.html.haml
@@ -1,0 +1,10 @@
+- content_for(:page_title) { "Mark development #{@development.application_number} as completed – " + t("page_title_prefix") }
+
+.govuk-width-container
+  = link_to "Back", developments_path, class: "govuk-back-link"
+  .govuk-grid-row
+    .govuk-grid-column-full-from-desktop
+      %h1.govuk-heading-l Mark development #{@development.application_number} as completed
+
+      = form_for @development, url: complete_development_path(@development) do |form|
+        = form.submit 'Mark as completed', class: "govuk-button"

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -11,11 +11,7 @@
           %dt.govuk-summary-list__key
             Status
           %dd.govuk-summary-list__value
-            - case @development.state
-            - when 'draft'
-              %p.govuk-tag Draft
-            - when 'agreed'
-              %p.govuk-tag Agreed
+            %p.govuk-tag= @development.state.titleize
           %dd.govuk-summary-list__actions
             - case @development.state
             - when 'draft'
@@ -24,6 +20,9 @@
             - when 'agreed'
               = link_to start_confirmation_development_path(@development), class: "govuk-link" do
                 Mark as started
+            - when 'started'
+              = link_to complete_confirmation_development_path(@development), class: "govuk-link" do
+                Mark as completed
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -14,9 +14,16 @@
             - case @development.state
             - when 'draft'
               %p.govuk-tag Draft
+            - when 'agreed'
+              %p.govuk-tag Agreed
           %dd.govuk-summary-list__actions
-            = link_to agree_confirmation_development_path(@development), class: "govuk-link" do
-              Mark as agreed
+            - case @development.state
+            - when 'draft'
+              = link_to agree_confirmation_development_path(@development), class: "govuk-link" do
+                Mark as agreed
+            - when 'agreed'
+              = link_to start_confirmation_development_path(@development), class: "govuk-link" do
+                Mark as started
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -2,29 +2,48 @@
 
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"
-
   .govuk-grid-row
-    .govuk-grid-column-full{class: "govuk-!-margin-bottom-8"}
-      %h1.govuk-heading-xl{class: "govuk-!-margin-bottom-3"} Development #{@development.application_number}
-      = link_to 'Edit development', edit_development_path(@development), class: "govuk-body govuk-link", "aria-label": "edit development #{@development.application_number}"
+    .govuk-grid-column-full-from-desktop
+      %h1.govuk-heading-l Development #{@development.application_number}
+      %dl.govuk-summary-list{:class => "govuk-!-margin-bottom-9"}
 
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %h2.govuk-heading-m Proposal
-      %p.govuk-body= @development.proposal
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Status
+          %dd.govuk-summary-list__value
+            - case @development.state
+            - when 'draft'
+              %p.govuk-tag Draft
+          %dd.govuk-summary-list__actions
+            = link_to agree_confirmation_development_path(@development), class: "govuk-link" do
+              Mark as agreed
 
-    .govuk-grid-column-one-third
-      %h2.govuk-heading-m Address
-      %p.govuk-body= @development.site_address
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Proposal
+          %dd.govuk-summary-list__value
+            %p.govuk-body= @development.proposal
+          %dd.govuk-summary-list__actions
+            = link_to edit_development_path(@development), class: "govuk-link" do
+              Edit
+              %span.govuk-visually-hidden proposal
 
-- case @development.state
-- when 'draft'
-  %p Draft
-  = link_to 'Mark as agreed', agree_confirmation_development_path(@development)
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Address
+          %dd.govuk-summary-list__value
+            %p.govuk-body= @development.site_address
+          %dd.govuk-summary-list__actions
+            = link_to edit_development_path(@development), class: "govuk-link" do
+              Edit
+              %span.govuk-visually-hidden address
 
-  .govuk-grid-row
-    .govuk-grid-column-full
-      %h2.govuk-heading-l{class: "govuk-!-margin-top-3"} Dwellings
-      %p.govuk-body
-        There are #{@development.dwellings.count} dwellings on this development.
-        = link_to 'Manage dwellings', development_dwellings_path(@development), class: "govuk-body govuk-link", "aria-label": "manage dwellings for development #{@development.application_number}"
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Dwellings
+          %dd.govuk-summary-list__value
+            %p.govuk-body There are #{@development.dwellings.count} dwellings on this development.
+          %dd.govuk-summary-list__actions
+            = link_to development_dwellings_path(@development) do
+              Manage
+              %span.govuk-visually-hidden dwellings

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -17,6 +17,10 @@
       %h2.govuk-heading-m Address
       %p.govuk-body= @development.site_address
 
+- case @development.state
+- when 'draft'
+  %p Draft
+  = link_to 'Mark as agreed', agree_confirmation_development_path(@development)
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/developments/start_confirmation.html.haml
+++ b/app/views/developments/start_confirmation.html.haml
@@ -1,0 +1,10 @@
+- content_for(:page_title) { "Mark development #{@development.application_number} as agreed – " + t("page_title_prefix") }
+
+.govuk-width-container
+  = link_to "Back", developments_path, class: "govuk-back-link"
+  .govuk-grid-row
+    .govuk-grid-column-full-from-desktop
+      %h1.govuk-heading-l Mark development #{@development.application_number} as started
+
+      = form_for @development, url: start_development_path(@development) do |form|
+        = form.submit 'Mark as started', class: "govuk-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
     member do
       get :agree_confirmation
       patch :agree
+      get :start_confirmation
+      patch :start
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
 
   resources :developments do
     resources :dwellings
+    member do
+      get :agree_confirmation
+      patch :agree
+    end
   end
 
   get '/check', to: proc { [200, {}, ['OK']] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
       patch :agree
       get :start_confirmation
       patch :start
+      get :complete_confirmation
+      patch :complete
     end
   end
 

--- a/db/migrate/20191014135208_add_state_to_developments.rb
+++ b/db/migrate/20191014135208_add_state_to_developments.rb
@@ -1,0 +1,5 @@
+class AddStateToDevelopments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :developments, :state, :string, null: false, default: 'draft'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_114156) do
+ActiveRecord::Schema.define(version: 2019_10_14_135208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_114156) do
     t.text "proposal"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "state", default: "draft", null: false
   end
 
   create_table "dwellings", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,5 +16,6 @@ FactoryBot.define do
     application_number { 'AP/2019/1234' }
     site_address { '1 Site Address, London, SE1 1AA' }
     proposal { 'Build a building' }
+    state { 'draft' }
   end
 end

--- a/spec/features/agreeing_a_development_spec.rb
+++ b/spec/features/agreeing_a_development_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Marking a development as agreed', type: :feature do
+  scenario 'successfully' do
+    development = create(:development, state: 'draft')
+    login
+    click_link 'AP/2019/1234'
+    expect(page).to have_content 'Draft'
+    click_link 'Mark as agreed'
+    click_button 'Mark as agreed'
+    expect(page).to have_content 'Development marked as agreed'
+    development.reload
+    expect(development.state).to eq('agreed')
+  end
+end

--- a/spec/features/completing_a_development_spec.rb
+++ b/spec/features/completing_a_development_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Marking a development as completed', type: :feature do
+  scenario 'successfully' do
+    development = create(:development, state: 'started')
+    login
+    click_link 'AP/2019/1234'
+    expect(page).to have_content 'Started'
+    click_link 'Mark as completed'
+    click_button 'Mark as completed'
+    expect(page).to have_content 'Development marked as completed'
+    development.reload
+    expect(development.state).to eq('completed')
+  end
+end

--- a/spec/features/editing_developments_spec.rb
+++ b/spec/features/editing_developments_spec.rb
@@ -1,19 +1,39 @@
 require 'rails_helper'
 
 RSpec.feature 'Editing a development core details', type: :feature do
-  scenario 'successfully' do
+  scenario 'successfully - application number' do
     login
     create(:development)
     visit developments_path
     click_link 'AP/2019/1234'
-    click_link 'Edit development'
+    find('a', text: 'Edit proposal', visible: false).click
     fill_in 'Application number', with: 'AP/2019/1235'
-    fill_in 'Site address', with: 'new 1 Site Address, London, SE1 1AA'
-    fill_in 'Proposal', with: 'Build a building edited'
     click_button 'Save and continue'
     expect(page).to have_text('Development successfully saved')
     expect(page).to have_text('AP/2019/1235')
+  end
+
+  scenario 'successfully - site address' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    find('a', text: 'Edit address', visible: false).click
+    fill_in 'Site address', with: 'new 1 Site Address, London, SE1 1AA'
+    click_button 'Save and continue'
+    expect(page).to have_text('Development successfully saved')
     expect(page).to have_text('new 1 Site Address, London, SE1 1AA')
+  end
+
+  scenario 'successfully - proposal' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    find('a', text: 'Edit proposal', visible: false).click
+    fill_in 'Proposal', with: 'Build a building edited'
+    click_button 'Save and continue'
+    expect(page).to have_text('Development successfully saved')
     expect(page).to have_text('Build a building edited')
   end
 

--- a/spec/features/starting_a_development_spec.rb
+++ b/spec/features/starting_a_development_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Marking a development as started', type: :feature do
+  scenario 'successfully' do
+    development = create(:development, state: 'agreed')
+    login
+    click_link 'AP/2019/1234'
+    expect(page).to have_content 'Agreed'
+    click_link 'Mark as started'
+    click_button 'Mark as started'
+    expect(page).to have_content 'Development marked as started'
+    development.reload
+    expect(development.state).to eq('started')
+  end
+end

--- a/spec/models/development_spec.rb
+++ b/spec/models/development_spec.rb
@@ -1,4 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Development, type: :model do
+  describe '#state' do
+    it 'cannot be nil' do
+      development = build(:development, state: nil)
+      expect(development).to be_invalid
+    end
+
+    it 'cannot be blank' do
+      development = build(:development, state: '')
+      expect(development).to be_invalid
+    end
+
+    it 'cannot be an invalid state' do
+      development = build(:development, state: 'something-weird')
+      expect(development).to be_invalid
+    end
+
+    it 'can be a valid state' do
+      development = build(:development, state: 'draft')
+      expect(development).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
This pull request includes all 4 states: draft, agreed, started, completed, and moving linearly between the 4.

It therefore encompasses:

https://trello.com/c/OqvDojZ6/25-add-the-concept-of-status-for-a-development
https://trello.com/c/m3Xb4Rgg/26-newly-created-developments-have-a-default-status-of-draft
https://trello.com/c/c3ewniqs/27-draft-developments-can-be-progressed-to-agreed
https://trello.com/c/IZEi4kce/30-agreed-developments-can-be-progressed-to-started
https://trello.com/c/DSDrba9T/31-started-developments-can-be-progressed-to-completed
