### PR TITLE
Validate application number on development

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -8,9 +8,13 @@ class DevelopmentsController < ApplicationController
   end
 
   def create
-    @development = Development.create!(development_params)
-    flash[:notice] = 'Development successfully created'
-    redirect_to action: :index
+    @development = Development.new(development_params)
+    if @development.save
+      flash[:notice] = 'Development successfully created'
+      redirect_to action: :index
+    else
+      render action: :new
+    end
   end
 
   def show
@@ -23,9 +27,12 @@ class DevelopmentsController < ApplicationController
 
   def update
     @development = Development.find(params[:id])
-    @development.update(development_params)
-    flash[:notice] = 'Development successfully saved'
-    redirect_to action: :index
+    if @development.update(development_params)
+      flash[:notice] = 'Development successfully saved'
+      redirect_to action: :index
+    else
+      render action: :edit
+    end
   end
 
   def agree_confirmation

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -1,6 +1,7 @@
 class Development < ApplicationRecord
   has_many :dwellings, dependent: :destroy
 
+  validates :application_number, presence: true
   validates :state, presence: true
 
   include AASM

--- a/app/views/developments/edit.html.haml
+++ b/app/views/developments/edit.html.haml
@@ -3,6 +3,7 @@
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
 
+  = render partial: 'partials/error_block', locals: { record: @development }
   .govuk-grid-row
     .govuk-grid-column-full
       %fieldset.govuk-fieldset

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -1,6 +1,7 @@
 - content_for(:page_title) { page_title('Add a new development') }
 
 .govuk-width-container
+  = render partial: 'partials/error_block', locals: { record: @development }
   .govuk-grid-row
     .govuk-grid-column-full
       %fieldset.govuk-fieldset

--- a/app/views/dwellings/edit.html.haml
+++ b/app/views/dwellings/edit.html.haml
@@ -3,6 +3,7 @@
 .govuk-width-container
   = link_to "Back", development_dwellings_path(@development), class: "govuk-back-link"
 
+  = render partial: 'partials/error_block', locals: { record: @dwelling }
   .govuk-grid-row
     .govuk-grid-column-full
       %h1.govuk-heading-xl Edit dwelling

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -3,14 +3,7 @@
 .govuk-width-container
   = link_to "Back", development_path(@development), class: "govuk-back-link"
 
-  - if @dwelling.errors.any?
-    .govuk-error-summary{"aria-labelledby" => "error-summary-title", "data-module" => "govuk-error-summary", :role => "alert", :tabindex => "-1"}
-      %h2#error-summary-title.govuk-error-summary__title
-        There is a problem
-      .govuk-error-summary__body
-        %ul.govuk-list.govuk-error-summary__list
-          - @dwelling.errors.each do |attribute, error|
-            %li= link_to @dwelling.errors.full_message(attribute, error), "#dwelling_#{attribute}"
+  = render partial: 'partials/error_block', locals: { record: @dwelling }
 
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/partials/_error_block.html.haml
+++ b/app/views/partials/_error_block.html.haml
@@ -1,0 +1,8 @@
+- if record.errors.any?
+  .govuk-error-summary{"aria-labelledby" => "error-summary-title", "data-module" => "govuk-error-summary", :role => "alert", :tabindex => "-1"}
+    %h2#error-summary-title.govuk-error-summary__title
+      There is a problem
+    .govuk-error-summary__body
+      %ul.govuk-list.govuk-error-summary__list
+        - record.errors.each do |attribute, error|
+          %li= link_to record.errors.full_message(attribute, error), "##{record.class.to_s.underscore}_#{attribute}"

--- a/spec/features/creating_developments_spec.rb
+++ b/spec/features/creating_developments_spec.rb
@@ -14,6 +14,16 @@ RSpec.feature 'Creating developments', type: :feature do
     expect(page).to have_text('Build a building')
   end
 
+  scenario 'with validation error' do
+    login
+    click_link 'Add a new development'
+    fill_in 'Application number', with: ''
+    fill_in 'Site address', with: ''
+    fill_in 'Proposal', with: ''
+    click_button 'Save and continue'
+    expect(page).to have_content("Application number can't be blank")
+  end
+
   scenario 'unable to view if not logged in' do
     visit new_development_path
     expect(current_path).to eq(new_user_session_path)

--- a/spec/features/editing_developments_spec.rb
+++ b/spec/features/editing_developments_spec.rb
@@ -37,6 +37,19 @@ RSpec.feature 'Editing a development core details', type: :feature do
     expect(page).to have_text('Build a building edited')
   end
 
+  scenario 'with validation error' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Edit development'
+    fill_in 'Application number', with: ''
+    fill_in 'Site address', with: ''
+    fill_in 'Proposal', with: ''
+    click_button 'Save and continue'
+    expect(page).to have_content("Application number can't be blank")
+  end
+
   scenario 'unable to view if not logged in' do
     development = create(:development)
     visit edit_development_path(development)


### PR DESCRIPTION
It's not entirely clear yet which of these fields are mandatory to be able to create a development. Do developments start getting logged/discussed before the have an application number/site address/proposal set? Probably not, but we want to keep it flexible until we find out.

However, if you create a development without an application number, then things start breaking, so let's require that.