### PR TITLE
allow paragraph breaks in development proposal

### DIFF
--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -17,4 +17,4 @@
         %tr.govuk-table__row
           %th.govuk-table__header{scope: "row"}= link_to development.application_number, development_path(development), class: "govuk-link", "aria-label": "view development #{development.application_number}"
           %td.govuk-table__cell= development.site_address
-          %td.govuk-table__cell= development.proposal
+          %td.govuk-table__cell= simple_format(development.proposal, class: 'govuk-body')

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -28,7 +28,7 @@
           %dt.govuk-summary-list__key
             Proposal
           %dd.govuk-summary-list__value
-            %p.govuk-body= @development.proposal
+            = simple_format(@development.proposal, class: 'govuk-body')
           %dd.govuk-summary-list__actions
             = link_to edit_development_path(@development), class: "govuk-link" do
               Edit


### PR DESCRIPTION
Using [rails' `simple_format`](https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format) we can let users add paragraph breaks to the development proposal, for better readability.

<img width="1019" alt="after (index)" src="https://user-images.githubusercontent.com/822507/67385740-9163b200-f58b-11e9-847d-02f6e1983a8b.png">
<img width="1012" alt="after (show)" src="https://user-images.githubusercontent.com/822507/67385742-91fc4880-f58b-11e9-91f0-50dad390b9e7.png">
