### PR TITLE
Chore/22 move dwelling form

### DIFF
--- a/app/controllers/dwellings_controller.rb
+++ b/app/controllers/dwellings_controller.rb
@@ -6,14 +6,17 @@ class DwellingsController < ApplicationController
     @dwelling = Dwelling.new
   end
 
+  def new
+    @dwelling = Dwelling.new
+  end
+
   def create
     @dwelling = Dwelling.new(dwelling_params.merge(development: @development))
     if @dwelling.save
       flash[:notice] = 'Dwelling successfully added'
       redirect_to development_dwellings_path(@development)
     else
-      @dwellings = @development.dwellings
-      render action: :index
+      render action: :new
     end
   end
 

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -4,7 +4,7 @@
   = link_to "Back to all developments", developments_path, class: "govuk-back-link"
   .govuk-grid-row
     .govuk-grid-column-full-from-desktop
-      %h1.govuk-heading-l Development #{@development.application_number}
+      %h1.govuk-heading-xl Development #{@development.application_number}
       %dl.govuk-summary-list{:class => "govuk-!-margin-bottom-9"}
 
         .govuk-summary-list__row

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -3,11 +3,11 @@
 .govuk-width-container
   = link_to "Back to development", development_path(@development), class: "govuk-back-link"
 
-  = render partial: 'partials/error_block', locals: { record: @dwelling }
-
   .govuk-grid-row
     .govuk-grid-column-full
       %h1.govuk-heading-xl Dwellings for #{@development.application_number}
+
+      = link_to 'Add a new dwelling', new_development_dwelling_path, class: 'govuk-button'
 
       %table.govuk-table
         %caption.govuk-table__caption.govuk-visually-hidden Dwellings
@@ -29,12 +29,3 @@
               %td.govuk-table__cell.govuk-table__cell--numeric=dwelling.bedrooms
               %td.govuk-table__cell= distance_of_time_in_words(dwelling.updated_at, Time.now) + " ago"
               %td.govuk-table__cell= link_to 'Edit', edit_development_dwelling_path(@development, dwelling), class: "govuk-link", "aria-label": "Edit dwelling #{dwelling.id}"
-
-  .govuk-grid-row
-    .govuk-grid-column-full
-
-      %h2.govuk-heading-l{class: "govuk-!-margin-top-5"} Add a dwelling
-
-      = simple_form_for([@development, @dwelling]) do |form|
-        = render partial: 'fields', locals: { form: form }
-        = form.submit 'Add dwelling', class: "govuk-button"

--- a/app/views/dwellings/new.html.haml
+++ b/app/views/dwellings/new.html.haml
@@ -1,0 +1,13 @@
+.govuk-width-container
+  = link_to "Back to dwellings", development_dwellings_path(@development), class: "govuk-back-link"
+
+  = render partial: 'partials/error_block', locals: { record: @dwelling }
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+
+      %h1.govuk-heading-xl Add a dwelling
+
+      = simple_form_for([@development, @dwelling]) do |form|
+        = render partial: 'fields', locals: { form: form }
+        = form.submit 'Add dwelling', class: "govuk-button"

--- a/spec/features/managing_dwellings_of_a_new_development_spec.rb
+++ b/spec/features/managing_dwellings_of_a_new_development_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Managing dwellings of a new development', type: :feature do
     visit developments_path
     click_link 'AP/2019/1234'
     click_link 'Manage dwellings'
+    click_link 'Add a new dwelling'
     select 'open', from: 'Tenure'
     fill_in 'Number of habitable rooms', with: 2
     fill_in 'Number of bedrooms', with: 1
@@ -24,6 +25,7 @@ RSpec.feature 'Managing dwellings of a new development', type: :feature do
     visit developments_path
     click_link 'AP/2019/1234'
     click_link 'Manage dwellings'
+    click_link 'Add a new dwelling'
     select 'open', from: 'Tenure'
     fill_in 'Number of habitable rooms', with: ''
     fill_in 'Number of bedrooms', with: ''


### PR DESCRIPTION
moves the new dwelling form to its own page

- once the list of dwellings gets into double digits, the form is forced down the page and loses prominence
- adding a button atop the page keeps the feature easy to access

<img width="1041" alt="Screenshot 2019-10-23 at 16 11 14" src="https://user-images.githubusercontent.com/822507/67407816-fa5d2100-f5af-11e9-92e0-841492c4a01a.png">
<img width="1063" alt="Screenshot 2019-10-23 at 16 11 22" src="https://user-images.githubusercontent.com/822507/67407817-faf5b780-f5af-11e9-99ee-c24cadbd5597.png">
