### PR TITLE
Audit updates to a dwelling when it's development is not draft

### DIFF
--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -4,7 +4,7 @@ class Dwelling < ApplicationRecord
   audited(
     associated_with: :development,
     if: :audit_changes?,
-    on: [:create],
+    on: %i[create update],
     comment_required: true
   )
 

--- a/app/views/partials/changelog_descriptions/_dwelling_update.html.haml
+++ b/app/views/partials/changelog_descriptions/_dwelling_update.html.haml
@@ -1,0 +1,4 @@
+%p{class: 'govuk-!-margin-top-0'} Dwelling updated
+- audit.audited_changes.each do |key,change|
+  %p{class: 'govuk-!-margin-top-0'}
+    #{key.humanize} changed from "#{change[0]}" to "#{change[1]}"

--- a/spec/features/editing_dwellings_spec.rb
+++ b/spec/features/editing_dwellings_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Editing dwellings', type: :feature do
     click_link 'AP/2019/1234'
     click_link 'Manage dwellings'
     click_link 'Edit'
+    expect(page).to_not have_content('Changelog')
     select 'social', from: 'Tenure'
     fill_in 'Number of habitable rooms', with: 3
     fill_in 'Number of bedrooms', with: 2
@@ -18,6 +19,7 @@ RSpec.feature 'Editing dwellings', type: :feature do
     expect(dwelling.tenure).to eq('social')
     expect(dwelling.habitable_rooms).to eq(3)
     expect(dwelling.bedrooms).to eq(2)
+    expect(development.audits.count).to eq(0)
   end
 
   scenario 'validation error editing a dwelling' do
@@ -34,5 +36,50 @@ RSpec.feature 'Editing dwellings', type: :feature do
     click_button 'Save dwelling'
     expect(page).to have_content("Habitable rooms can't be blank")
     expect(page).to have_content("Bedrooms can't be blank")
+  end
+
+  scenario 'successfully editing a dwelling on an agreed development' do
+    user = login
+    development = create(:development)
+    dwelling = create(:dwelling, development: development)
+    development.agree!
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage dwellings'
+    click_link 'Edit'
+    select 'social', from: 'Tenure'
+    fill_in 'Number of habitable rooms', with: 3
+    fill_in 'Number of bedrooms', with: 2
+    fill_in 'Changelog', with: 'Testing changelog'
+    click_button 'Save dwelling'
+    expect(page).to have_content('Dwelling successfully saved')
+    dwelling.reload
+    expect(dwelling.tenure).to eq('social')
+    expect(dwelling.habitable_rooms).to eq(3)
+    expect(dwelling.bedrooms).to eq(2)
+    visit development_path(development)
+    within '.changelog_row' do
+      expect(page).to have_content('Dwelling updated')
+      expect(page).to have_content('Tenure changed from "open" to "social"')
+      expect(page).to have_content('Habitable rooms changed from "1" to "3"')
+      expect(page).to have_content('Bedrooms changed from "1" to "2"')
+      expect(page).to have_content('Testing changelog')
+      expect(page).to have_content(user.email)
+    end
+  end
+
+  scenario 'no changelog when required' do
+    login
+    development = create(:development)
+    create(:dwelling, development: development)
+    development.agree!
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage dwellings'
+    click_link 'Edit'
+    select 'social', from: 'Tenure'
+    fill_in 'Changelog', with: ''
+    click_button 'Save dwelling'
+    expect(page).to have_content("Audit comment Comment can't be blank")
   end
 end


### PR DESCRIPTION
Nothing novel here compared to previous two audit actions.