### PR TITLE
Add faker to all Rails environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem 'aasm'
 
 gem 'audited'
 
+# Used by seeds.rb
+gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -50,7 +53,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'
 end
 
 group :development, :test do


### PR DESCRIPTION
We want to be able to run `rake db:seed` on the staging environment, so we need access to the faker gem.