### PR TITLE
(fix) adds missing class to link

### DIFF
--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -50,7 +50,7 @@
           %dd.govuk-summary-list__value
             %p.govuk-body=t('dwellings_count', count: @development.dwellings.count)
           %dd.govuk-summary-list__actions
-            = link_to development_dwellings_path(@development) do
+            = link_to development_dwellings_path(@development), class: "govuk-link" do
               Manage
               %span.govuk-visually-hidden dwellings
 


### PR DESCRIPTION
Before:
<img width="259" alt="before" src="https://user-images.githubusercontent.com/822507/67872471-e7a39880-fb29-11e9-958f-a61e80db35f8.png">
After:
<img width="229" alt="after" src="https://user-images.githubusercontent.com/822507/67872473-e96d5c00-fb29-11e9-95de-c5cb5fb50bbe.png">
