### PR TITLE
Turn off auditing on seeds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     Exclude:
       - 'db/migrate/**/*'
       - 'db/schema.rb'
+      - 'db/seeds.rb'
       - 'bin/**/*'
       - 'node_modules/**/*'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,32 +8,36 @@
 
 User.create!(email: 'email@example.com', password: 'password', password_confirmation: 'password')
 
-100.times do
-  app_year = Random.rand(2017...2019)
-  number = Random.rand(5001...9999)
-  app_number = "AP/#{app_year}/#{number}"
-  proposal = Faker::Lorem.sentence(word_count: 7, supplemental: true, random_words_to_add: 7)
-  streets = Faker::Address.street_name
-  districts = [
-    'Abbey Wood, SE2', 'Blackheath, SE3', 'Brockley, SE4', 'Camberwell, SE5', 'Catford, SE6',
-    'Charlton, SE7', 'Deptford, SE8', 'Eltham, SE9', 'Greenwich, SE10', 'Kennington, SE11', 'Grove Park, SE12',
-    'Lewisham, SE13', 'New Cross, SE14', 'Peckham, SE15', 'Rotherhithe, SE16', 'Walworth, SE17', 'Woolwich, SE18',
-    'Norwood, SE19', 'Dulwich, SE21', 'East Dulwich, SE22', 'Forest Hill, SE23', 'Herne Hill, SE24',
-    'South Norwood, SE25', 'Sydenham, SE26', 'West Norwood, SE27', 'Thamesmead, SE28'
-  ]
-  address = "#{streets}, #{districts.sample}"
-  state = %w[draft agreed started completed].sample
+Development.without_auditing do
+  Dwelling.without_auditing do
+    100.times do
+      app_year = Random.rand(2017...2019)
+      number = Random.rand(5001...9999)
+      app_number = "AP/#{app_year}/#{number}"
+      proposal = Faker::Lorem.sentence(word_count: 7, supplemental: true, random_words_to_add: 7)
+      streets = Faker::Address.street_name
+      districts = [
+        'Abbey Wood, SE2', 'Blackheath, SE3', 'Brockley, SE4', 'Camberwell, SE5', 'Catford, SE6',
+        'Charlton, SE7', 'Deptford, SE8', 'Eltham, SE9', 'Greenwich, SE10', 'Kennington, SE11', 'Grove Park, SE12',
+        'Lewisham, SE13', 'New Cross, SE14', 'Peckham, SE15', 'Rotherhithe, SE16', 'Walworth, SE17', 'Woolwich, SE18',
+        'Norwood, SE19', 'Dulwich, SE21', 'East Dulwich, SE22', 'Forest Hill, SE23', 'Herne Hill, SE24',
+        'South Norwood, SE25', 'Sydenham, SE26', 'West Norwood, SE27', 'Thamesmead, SE28'
+      ]
+      address = "#{streets}, #{districts.sample}"
+      state = %w[draft agreed started completed].sample
 
-  development = Development.create!(
-    application_number: app_number, site_address: address, proposal: proposal, state: state
-  )
+      development = Development.create!(
+        application_number: app_number, site_address: address, proposal: proposal, state: state
+      )
 
-  Random.rand(3...12).times do
-    Dwelling.create!(
-      development_id: development.id,
-      tenure: %w[open social intermediate].sample,
-      habitable_rooms: Random.rand(2...4),
-      bedrooms: Random.rand(1...2)
-    )
+      Random.rand(3...12).times do
+        Dwelling.create!(
+          development_id: development.id,
+          tenure: %w[open social intermediate].sample,
+          habitable_rooms: Random.rand(2...4),
+          bedrooms: Random.rand(1...2)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
When running the seeds, the system requires would create an audit log for any dwellings added to a dwelling that isn't in a draft state. This would also error because we're not adding an audit_comment to these changes.

I've turned off auditing for these seeds.
I also added seed.rb to the rubocop ignore list, as it was complaining about the block being too large, which is OK in this case.