### PR TITLE
Feature/url obsfucation

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -70,11 +70,11 @@ class DevelopmentsController < ApplicationController
   end
 
   def completion_response_form
-    @development = Development.find(params[:id])
+    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak])
   end
 
   def completion_response
-    @development = Development.find(params[:id])
+    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak])
     @development.update!(completion_response_params)
     @development.reload
     if @development.completion_response_filled?

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -4,6 +4,9 @@ class Development < ApplicationRecord
 
   validates :application_number, presence: true
   validates :state, presence: true
+  validates :developer_access_key, presence: true
+
+  before_validation :set_developer_access_key, on: :create
 
   audited(
     if: :audit_changes?,
@@ -47,6 +50,10 @@ class Development < ApplicationRecord
   end
 
   private
+
+  def set_developer_access_key
+    self.developer_access_key = SecureRandom.urlsafe_base64(20)
+  end
 
   def comment_required_state?
     # Monkey patch explanation:

--- a/app/views/developments/_developer_response_required.haml
+++ b/app/views/developments/_developer_response_required.haml
@@ -2,4 +2,4 @@
   %h2.govuk-heading-s Developer completion response needed
   %p.govuk-body Copy and paste the URL below and send it to the developer. When they've filled out the form, you'll see the responses here.
   %label.govuk-label{for: 'developer_response_url'} Developer response URL
-  %input{type: 'text', id: 'developer_response_url', class: 'govuk-input govuk-!-width-full', value: completion_response_form_development_url(@development)}
+  %input{type: 'text', id: 'developer_response_url', class: 'govuk-input govuk-!-width-full', value: completion_response_form_development_url(@development, dak: @development.developer_access_key)}

--- a/app/views/developments/completion_response_form.html.haml
+++ b/app/views/developments/completion_response_form.html.haml
@@ -9,6 +9,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       = simple_form_for(@development, url: completion_response_development_path(@development)) do |form|
+        = hidden_field_tag :dak, @development.developer_access_key
         = form.fields_for :dwellings, @development.dwellings.within_s106 do |dwelling_form|
           .govuk-fieldset{class: 'govuk-!-margin-top-9 govuk-!-margin-bottom-9'}
             %legend.govuk-fieldset__legend.govuk-fieldset__legend--m

--- a/db/migrate/20191104123906_add_developer_access_key_to_developments.rb
+++ b/db/migrate/20191104123906_add_developer_access_key_to_developments.rb
@@ -1,0 +1,5 @@
+class AddDeveloperAccessKeyToDevelopments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :developments, :developer_access_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_31_132036) do
+ActiveRecord::Schema.define(version: 2019_11_04_123906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_10_31_132036) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "state", default: "draft", null: false
+    t.string "developer_access_key"
   end
 
   create_table "dwellings", force: :cascade do |t|

--- a/spec/features/developer_completion_response_spec.rb
+++ b/spec/features/developer_completion_response_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
   end
 
   scenario 'successfully and completely' do
-    visit completion_response_form_development_path(@development)
+    visit completion_response_form_development_path(@development, dak: @development.developer_access_key)
     expect(page).to_not have_content('Open')
 
     within ".dwelling_#{@intermediate_dwelling.id}" do
@@ -39,7 +39,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
   end
 
   scenario 'successfully but incomplete' do
-    visit completion_response_form_development_path(@development)
+    visit completion_response_form_development_path(@development, dak: @development.developer_access_key)
 
     within ".dwelling_#{@intermediate_dwelling.id}" do
       fill_in 'Address', with: '1 Newbuild House'
@@ -59,5 +59,11 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     @intermediate_dwelling.reload
     expect(@intermediate_dwelling.address).to eq('1 Newbuild House')
     expect(@intermediate_dwelling.registered_provider).to eq(@registered_provider1)
+  end
+
+  scenario 'with wrong access key' do
+    expect do
+      visit completion_response_form_development_path(@development, dak: 'wild-guess')
+    end.to raise_error(ActiveRecord::RecordNotFound)
   end
 end


### PR DESCRIPTION
Before this PR, the developer completion response form does not require a sign in and is just using the consecutive ID for developments, so would be very easy to guess.

This PR adds a very hard to guess query parameter to the URLs to add protection.

These IDs will be generated when a development is created (including from seeds.rb), but if you don't want to re-run the seeds, you can run the code below in a rails console to backfill them.

`Development.all.each {|d| Development.without_auditing { d.send(:set_developer_access_key); d.save!}}`

Please don't merge just yet, as it will change the URLs that I just shared in slack.