### PR TITLE
Limit access to developer reponse form

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -70,11 +70,13 @@ class DevelopmentsController < ApplicationController
   end
 
   def completion_response_form
-    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak])
+    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak], state: 'completed')
+
+    render action: :completion_response if @development.completion_response_filled?
   end
 
   def completion_response
-    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak])
+    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak], state: 'completed')
     @development.update!(completion_response_params)
     @development.reload
     if @development.completion_response_filled?

--- a/spec/features/developer_completion_response_spec.rb
+++ b/spec/features/developer_completion_response_spec.rb
@@ -66,4 +66,20 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
       visit completion_response_form_development_path(@development, dak: 'wild-guess')
     end.to raise_error(ActiveRecord::RecordNotFound)
   end
+
+  scenario 'development is not in a completed state' do
+    @development.update!(state: 'started')
+    expect do
+      visit completion_response_form_development_path(@development, dak: @development.developer_access_key)
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  scenario 'response form has already been completed' do
+    Dwelling.without_auditing do
+      @intermediate_dwelling.update!(address: '1 address', registered_provider: @registered_provider1)
+      @social_dwelling.update!(address: '2 address', registered_provider: @registered_provider1)
+    end
+    visit completion_response_form_development_path(@development, dak: @development.developer_access_key)
+    expect(page).to have_content('Your development information has been submitted')
+  end
 end


### PR DESCRIPTION
Because the developer response form does not require sign-in, we want to restrict it a bit more. This captures two sceanarios:

- The developer visits a response form URL after they have already filled everything in. They are shown the completion page, instead of being able to edit what they had previously filled in
- The developer somehow finds the URL for the repsonse form before the development is in a `completed` state. This is very unlikely, but I've made it a 404 anyway.