### PR TITLE
Use fork of Audited gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'devise'
 
 gem 'aasm'
 
-gem 'audited'
+gem 'audited', git: 'git@github.com:james/audited.git', branch: 'southwark'
 
 # Used by seeds.rb
 gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: git@github.com:james/audited.git
+  revision: dc144779bff52561f18968f1ca2a9d3eff20d6c0
+  branch: southwark
+  specs:
+    audited (4.9.0)
+      activerecord (>= 4.2, < 6.1)
+
+GIT
   remote: https://github.com/faker-ruby/faker.git
   revision: 4ba30fb28072e942420ebf2d58da73969ae6159b
   branch: master
@@ -69,8 +77,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    audited (4.9.0)
-      activerecord (>= 4.2, < 6.1)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.5)
@@ -291,7 +297,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  audited
+  audited!
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -54,13 +54,4 @@ class Development < ApplicationRecord
   def set_developer_access_key
     self.developer_access_key = SecureRandom.urlsafe_base64(20)
   end
-
-  def comment_required_state?
-    # Monkey patch explanation:
-    # The Audited gem doesn't create a changelog if there are no audited_changes
-    # eg in the situation where we're only changing `state`, and state is ignored by
-    # audited. So in this situation, we shouldn't require a comment either.
-    # TODO: Make this a PR on the audited gem itself
-    super && audited_changes.present?
-  end
 end

--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -19,16 +19,4 @@ class Dwelling < ApplicationRecord
   validates :bedrooms, presence: true
 
   delegate :audit_changes?, to: :development
-
-  private
-
-  def comment_required_state?
-    # Monkey patch explanation:
-    # The Audited gem doesn't create a changelog if there are no audited_changes
-    # eg in the situation where we're only changing `address`, and address is
-    # ignored by audited. So in this situation, we shouldn't require a comment
-    # either.
-    # TODO: Make this a PR on the audited gem itself
-    super && audited_changes.present?
-  end
 end

--- a/spec/features/creating_dwellings_spec.rb
+++ b/spec/features/creating_dwellings_spec.rb
@@ -70,6 +70,6 @@ RSpec.feature 'Creating dwellings', type: :feature do
     click_link 'Add a new dwelling'
     fill_in 'Changelog', with: ''
     click_button 'Add dwelling'
-    expect(page).to have_content("Audit comment Comment can't be blank")
+    expect(page).to have_content("Audit comment can't be blank")
   end
 end

--- a/spec/features/deleting_dwellings_spec.rb
+++ b/spec/features/deleting_dwellings_spec.rb
@@ -50,6 +50,6 @@ RSpec.feature 'Deleting dwellings', type: :feature do
     click_link 'Delete dwelling'
     fill_in 'Deletion reason', with: ''
     click_button 'Delete dwelling'
-    expect(page).to have_content("Audit comment Comment can't be blank")
+    expect(page).to have_content("Audit comment can't be blank")
   end
 end

--- a/spec/features/editing_developments_spec.rb
+++ b/spec/features/editing_developments_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Editing a development core details', type: :feature do
     fill_in 'Proposal', with: 'Build a building edited'
     fill_in 'Changelog', with: ''
     click_button 'Save and continue'
-    expect(page).to have_content("Audit comment Comment can't be blank")
+    expect(page).to have_content("Audit comment can't be blank")
   end
 
   scenario 'unable to view if not logged in' do

--- a/spec/features/editing_dwellings_spec.rb
+++ b/spec/features/editing_dwellings_spec.rb
@@ -80,6 +80,6 @@ RSpec.feature 'Editing dwellings', type: :feature do
     select 'social', from: 'Tenure'
     fill_in 'Changelog', with: ''
     click_button 'Save dwelling'
-    expect(page).to have_content("Audit comment Comment can't be blank")
+    expect(page).to have_content("Audit comment can't be blank")
   end
 end


### PR DESCRIPTION
We had two bugs with the audited gem, and I've opened PRs for both of them:

https://github.com/collectiveidea/audited/pull/522
https://github.com/collectiveidea/audited/pull/523

In the meantime, while we're waiting for them to hopefully be approved and merged, I have created my own fork with a branch that has both of those changes in.

This means that we no longer need the monkey pathes in the dwelling and development models. Also update the specs to reflect the new, fixed error messages.