### PR TITLE
renders the developer responses for dwellings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,4 +8,6 @@ $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
 @import "components/subnavigation";
 @import "components/state-labels";
 @import "components/highlight";
+@import "components/width-container";
+@import "components/table-scrollable";
 @import "utilities";

--- a/app/assets/stylesheets/components/_table-scrollable.scss
+++ b/app/assets/stylesheets/components/_table-scrollable.scss
@@ -1,0 +1,3 @@
+.table-scrollable {
+  overflow-x: scroll;
+}

--- a/app/assets/stylesheets/components/_width-container.scss
+++ b/app/assets/stylesheets/components/_width-container.scss
@@ -1,0 +1,5 @@
+@media (min-width: 1020px) {
+  .govuk-width-container {
+    max-width: 94%;
+  }
+}

--- a/app/views/developments/complete_confirmation.html.haml
+++ b/app/views/developments/complete_confirmation.html.haml
@@ -6,5 +6,11 @@
     .govuk-grid-column-full-from-desktop
       %h1.govuk-heading-l Mark development #{@development.application_number} as completed
 
+      .govuk-warning-text
+        %span.govuk-warning-text__icon{"aria-hidden" => "true"} !
+        %strong.govuk-warning-text__text
+          %span.govuk-warning-text__assistive Warning
+          You won't be able to add any more dwellings to this development if you mark it as completed
+
       = form_for @development, url: complete_development_path(@development) do |form|
         = form.submit 'Mark as completed', class: "govuk-button"

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -7,25 +7,32 @@
     .govuk-grid-column-full
       %h1.govuk-heading-xl Dwellings for #{@development.application_number}
 
-      = link_to 'Add a new dwelling', new_development_dwelling_path, class: 'govuk-button'
+      = link_to 'Add a new dwelling', new_development_dwelling_path, class: 'govuk-button' unless @development.completed?
 
-      %table.govuk-table
-        %caption.govuk-table__caption.govuk-visually-hidden Dwellings
-        %thead.govuk-table__head
-          %tr.govuk-table__row
-            %th{class: "govuk-table__header", scope: "col"} ID
-            %th{class: "govuk-table__header", scope: "col"} Tenure
-            %th{class: "govuk-table__header govuk-table__header--numeric", scope: "col"} Habitable rooms
-            %th{class: "govuk-table__header govuk-table__header--numeric", scope: "col"} Bedrooms
-            %th{class: "govuk-table__header", scope: "col"} Last updated
-            %th{class: "govuk-table__header", scope: "col"} Actions
+      = render 'developments/developer_response_given' if @development.completion_response_filled?
 
-        %tbody.govuk-table__body
-          -@development.dwellings.each do |dwelling|
+      .table-scrollable
+        %table.govuk-table
+          %caption.govuk-table__caption.govuk-visually-hidden Dwellings
+          %thead.govuk-table__head
             %tr.govuk-table__row
-              %th.govuk-table__header{scope: "row"}= dwelling.id
-              %td.govuk-table__cell= dwelling.tenure
-              %td.govuk-table__cell.govuk-table__cell--numeric=dwelling.habitable_rooms
-              %td.govuk-table__cell.govuk-table__cell--numeric=dwelling.bedrooms
-              %td.govuk-table__cell= distance_of_time_in_words(dwelling.updated_at, Time.now) + " ago"
-              %td.govuk-table__cell= link_to 'Edit', edit_development_dwelling_path(@development, dwelling), class: "govuk-link", "aria-label": "Edit dwelling #{dwelling.id}"
+              %th{class: "govuk-table__header", scope: "col"} ID
+              %th{class: "govuk-table__header", scope: "col"} Address
+              %th{class: "govuk-table__header", scope: "col"} Registered provider
+              %th{class: "govuk-table__header", scope: "col"} Tenure
+              %th{class: "govuk-table__header govuk-table__header--numeric", scope: "col"} Habitable rooms
+              %th{class: "govuk-table__header govuk-table__header--numeric", scope: "col"} Bedrooms
+              %th{class: "govuk-table__header", scope: "col"} Last updated
+              %th{class: "govuk-table__header", scope: "col"} Actions
+
+          %tbody.govuk-table__body
+            -@development.dwellings.each do |dwelling|
+              %tr.govuk-table__row
+                %th.govuk-table__header{scope: "row"}= dwelling.id
+                %td.govuk-table__cell= dwelling.address.present? ? dwelling.address : 'Not yet supplied'
+                %td.govuk-table__cell= dwelling.registered_provider.present? ? dwelling.registered_provider.name : 'Not yet supplied'
+                %td.govuk-table__cell= dwelling.tenure
+                %td.govuk-table__cell.govuk-table__cell--numeric=dwelling.habitable_rooms
+                %td.govuk-table__cell.govuk-table__cell--numeric=dwelling.bedrooms
+                %td.govuk-table__cell= distance_of_time_in_words(dwelling.updated_at, Time.now) + " ago"
+                %td.govuk-table__cell= link_to 'Edit', edit_development_dwelling_path(@development, dwelling), class: "govuk-link", "aria-label": "Edit dwelling #{dwelling.id}"


### PR DESCRIPTION
- if the developer response is submitted, show them in the dwellings table
- overrides the GOV.UK container max width and applies an elastic width for optimal display
- if the screen width gets too narrow to contain the table, it becomes horizontally scrollable
- removes the 'add a dwelling' button if a developer response exists

**without developer response:**
<img width="1637" alt="Screenshot 2019-11-05 at 14 57 58" src="https://user-images.githubusercontent.com/822507/68223090-0ac7bf80-ffe4-11e9-8acb-ed1a6592ece0.png">

**with developer response:**
<img width="1637" alt="Screenshot 2019-11-05 at 15 41 39" src="https://user-images.githubusercontent.com/822507/68223107-11eecd80-ffe4-11e9-9820-b8e17c511e35.png">
