### PR TITLE
shows a better blank state for the changelog

### DIFF
--- a/app/views/partials/_changelog.haml
+++ b/app/views/partials/_changelog.haml
@@ -1,19 +1,25 @@
 .bg-light-grey{class: 'govuk-!-padding-top-9 govuk-!-padding-bottom-9'}
   .govuk-width-container
-    %table.govuk-table
-      %caption.govuk-table__caption.govuk-heading-m Changelog
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header{scope: 'col'} Changed at
-          %th.govuk-table__header{scope: 'col'} Changes made by
-          %th.govuk-table__header{scope: 'col'} Changes made
-      %tbody.govuk-table__body
-        - @development.own_and_associated_audits.order(created_at: :asc).each do |audit|
-          %tr.govuk-table__row.changelog_row
-            %th.govuk-table__header{class: 'govuk-!-width-one-quarter', scope: 'row'}= audit.created_at.to_s(:short)
-            %td.govuk-table__cell{class: 'govuk-!-width-one-quarter'}= audit.user&.email
-            %td.govuk-table__cell{class: 'govuk-!-width-one-half'}
-              = render partial: "partials/changelog_descriptions/#{audit.auditable_type.underscore}_#{audit.action}", locals: {audit: audit}
-              %footer{class: 'govuk-!-font-weight-bold govuk-!-font-size-16'}
-                Comments:
-                = audit.comment if audit.comment?
+
+    -if @development.own_and_associated_audits.any?
+      %table.govuk-table
+        %caption.govuk-table__caption.govuk-heading-m Changelog
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{scope: 'col'} Changed at
+            %th.govuk-table__header{scope: 'col'} Changes made by
+            %th.govuk-table__header{scope: 'col'} Changes made
+        %tbody.govuk-table__body
+          - @development.own_and_associated_audits.order(created_at: :asc).each do |audit|
+            %tr.govuk-table__row.changelog_row
+              %th.govuk-table__header{class: 'govuk-!-width-one-quarter', scope: 'row'}= audit.created_at.to_s(:short)
+              %td.govuk-table__cell{class: 'govuk-!-width-one-quarter'}= audit.user&.email
+              %td.govuk-table__cell{class: 'govuk-!-width-one-half'}
+                = render partial: "partials/changelog_descriptions/#{audit.auditable_type.underscore}_#{audit.action}", locals: {audit: audit}
+                %footer{class: 'govuk-!-font-weight-bold govuk-!-font-size-16'}
+                  Comments:
+                  = audit.comment if audit.comment?
+
+    - else
+      %h2.govuk-heading-m Changelog
+      %p.govuk-body There are no changes recorded on this development.


### PR DESCRIPTION
**Before:**
<img width="1024" alt="Screenshot 2019-11-05 at 17 32 07" src="https://user-images.githubusercontent.com/822507/68231470-0c4cb400-fff3-11e9-8f14-34f687c44566.png">

**After:**
<img width="1024" alt="Screenshot 2019-11-05 at 17 32 18" src="https://user-images.githubusercontent.com/822507/68231479-0e167780-fff3-11e9-9b60-fa5e7b278acc.png">

