### PR TITLE
(fix) removes hardcoded active nav highlighting

### DIFF
--- a/app/assets/stylesheets/components/_subnavigation.scss
+++ b/app/assets/stylesheets/components/_subnavigation.scss
@@ -8,6 +8,7 @@
     a {
       @include govuk-font(19, $weight: bold);
       color: $govuk-link-colour;
+      border-bottom: 3px solid transparent !important;
       display: inline-block;
       padding: 15px 10px 10px 10px;
       margin-right: 15px;

--- a/app/views/partials/_subnavigation.haml
+++ b/app/views/partials/_subnavigation.haml
@@ -2,7 +2,7 @@
   %nav#nav
     .navbar
       %ul.navbar__list-items
-        %li.active
+        %li
           = link_to t('navigation.developments'), developments_path
         %li
           = link_to t('navigation.new_development'), new_development_path


### PR DESCRIPTION
**Before:**
<img width="881" alt="Screenshot 2019-11-11 at 14 58 13" src="https://user-images.githubusercontent.com/822507/68597602-27a53c80-0495-11ea-903a-3df02988ae05.png">
**After:**
<img width="627" alt="Screenshot 2019-11-11 at 15 03 10" src="https://user-images.githubusercontent.com/822507/68597608-2b38c380-0495-11ea-851e-2a3f028df84c.png">