### PR TITLE
Use HTTPS for audited gem git reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'devise'
 
 gem 'aasm'
 
-gem 'audited', git: 'git@github.com:james/audited.git', branch: 'southwark'
+gem 'audited', git: 'https://github.com/james/audited.git', branch: 'southwark'
 
 # Used by seeds.rb
 gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GIT
-  remote: git@github.com:james/audited.git
-  revision: dc144779bff52561f18968f1ca2a9d3eff20d6c0
-  branch: southwark
-  specs:
-    audited (4.9.0)
-      activerecord (>= 4.2, < 6.1)
-
-GIT
   remote: https://github.com/faker-ruby/faker.git
   revision: 4ba30fb28072e942420ebf2d58da73969ae6159b
   branch: master
   specs:
     faker (2.6.0)
       i18n (>= 1.6, < 1.8)
+
+GIT
+  remote: https://github.com/james/audited.git
+  revision: dc144779bff52561f18968f1ca2a9d3eff20d6c0
+  branch: southwark
+  specs:
+    audited (4.9.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
I was using my own personal git url, rather than the public HTTPS url, which was causing problems with deploys.