### PR TITLE
Add searching of developments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem 'aasm'
 
 gem 'audited', git: 'https://github.com/james/audited.git', branch: 'southwark'
 
+gem 'pg_search'
+
 # Used by seeds.rb
 gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,9 @@ GEM
     parser (2.6.4.1)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pg_search (2.3.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -309,6 +312,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pg_search
   puma (~> 3.11)
   rails (~> 6.0.0)
   rspec-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,4 +10,5 @@ $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
 @import "components/highlight";
 @import "components/width-container";
 @import "components/table-scrollable";
+@import "components/development-search";
 @import "utilities";

--- a/app/assets/stylesheets/components/_development-search.scss
+++ b/app/assets/stylesheets/components/_development-search.scss
@@ -1,0 +1,6 @@
+.development-search {
+  input[type='text'] {
+    width: 65%;
+    margin-bottom: govuk-spacing(3);
+  }
+}

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,7 +1,11 @@
 class DevelopmentsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[completion_response_form completion_response]
   def index
-    @developments = Development.all
+    @developments = if params.dig(:search, :q).present?
+                      Development.search(params[:search][:q])
+                    else
+                      Development.all
+                    end
   end
 
   def new

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -33,6 +33,13 @@ class Development < ApplicationRecord
     end
   end
 
+  include PgSearch::Model
+  pg_search_scope :search,
+                  against: %i[application_number proposal site_address],
+                  associated_against: {
+                    dwellings: [:address],
+                  }
+
   def audit_changes?
     state != 'draft'
   end

--- a/app/views/developments/_search.haml
+++ b/app/views/developments/_search.haml
@@ -1,0 +1,4 @@
+.development-search
+  = simple_form_for :search, method: :get, defaults: {wrapper: false} do |form|
+    = form.input :q, label: 'Search', required: true, input_html: { value: params.dig(:search, :q) }
+    = form.button :submit, 'Search'

--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -4,6 +4,10 @@
 
   %h1.govuk-heading-xl= t('developments.index_heading')
 
+  = simple_form_for :search, method: :get do |form|
+    = form.input :q, label: 'Search', required: true, input_html: { value: params.dig(:search, :q) }
+    = form.button :submit, 'Search'
+
   %table.govuk-table
     %caption.govuk-table__caption.govuk-visually-hidden= t('developments.index_heading')
     %thead.govuk-table__head

--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -2,13 +2,17 @@
 
 .govuk-width-container
 
-  %h1.govuk-heading-xl= t('developments.index_heading')
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds-from-desktop
+      %h1.govuk-heading-xl= t('developments.index_heading')
 
-  = simple_form_for :search, method: :get do |form|
-    = form.input :q, label: 'Search', required: true, input_html: { value: params.dig(:search, :q) }
-    = form.button :submit, 'Search'
+    .govuk-grid-column-one-third-from-desktop
+      = render 'search'
 
-  %table.govuk-table
+  -  if params.dig(:search, :q).present?
+    =link_to 'Clear search results', developments_path, class: 'govuk-link'
+
+  %table.govuk-table{class: 'govuk-!-margin-top-6'}
     %caption.govuk-table__caption.govuk-visually-hidden= t('developments.index_heading')
     %thead.govuk-table__head
       %tr.govuk-table__row

--- a/spec/features/searching_developments_spec.rb
+++ b/spec/features/searching_developments_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching developments', type: :feature do
+  before do
+    development1 = create(:development, application_number: 'APP1', proposal: 'Build development', site_address: '1 Old Street')
+    create(:development, application_number: 'APP2', proposal: 'Build houses', site_address: '1 New Street')
+    create(:dwelling, development: development1, address: 'Flat 1, Flower House, SE1 1AA')
+  end
+
+  scenario 'by application number' do
+    login
+    fill_in 'Search', with: 'App2'
+    click_button 'Search'
+    expect(page).to have_content('Build houses')
+    expect(page).to_not have_content('Build development')
+  end
+
+  scenario 'by proposal' do
+    login
+    fill_in 'Search', with: 'build development'
+    click_button 'Search'
+    expect(page).to have_content('APP1')
+    expect(page).to_not have_content('APP2')
+  end
+
+  scenario 'by site address' do
+    login
+    fill_in 'Search', with: 'street Old'
+    click_button 'Search'
+    expect(page).to have_content('APP1')
+    expect(page).to_not have_content('APP2')
+  end
+
+  scenario 'by dwelling address' do
+    login
+    fill_in 'Search', with: 'Flower House'
+    click_button 'Search'
+    expect(page).to have_content('APP1')
+    expect(page).to_not have_content('APP2')
+  end
+end


### PR DESCRIPTION
Uses PGSearch to allow searching the following fields:

- a development's application number
- a development's proposal
- a development's site address
- all of the development's dwellings' addresses

Reading the documentation, this might rely on a modern enough Postgres with the certain features enabled, but I think they're pretty standard. Works fine with my local Postgres out of the box. We'll find out if they're enabled for our CI and staging environment soon!