### PR TITLE
Validate uniquness of dwelling reference ID within development

### DIFF
--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -17,7 +17,7 @@ class Dwelling < ApplicationRecord
   validates :tenure, presence: true
   validates :habitable_rooms, presence: true
   validates :bedrooms, presence: true
-  validates :reference_id, presence: true
+  validates :reference_id, presence: true, uniqueness: { scope: :development }
 
   delegate :audit_changes?, to: :development
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     tenure { 'open' }
     habitable_rooms { 1 }
     bedrooms { 1 }
-    reference_id { 'A1' }
+    sequence(:reference_id) { |n| "A#{n}" }
     development
   end
 

--- a/spec/features/creating_dwellings_spec.rb
+++ b/spec/features/creating_dwellings_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Creating dwellings', type: :feature do
     expect(development.audits.count).to eq(0)
   end
 
-  scenario 'validation error adding a dwelling' do
+  scenario 'validation presence error adding a dwelling' do
     login
     create(:development)
     visit developments_path
@@ -38,6 +38,22 @@ RSpec.feature 'Creating dwellings', type: :feature do
     expect(page).to have_content("Habitable rooms can't be blank")
     expect(page).to have_content("Bedrooms can't be blank")
     expect(page).to have_content("Reference ID can't be blank")
+  end
+
+  scenario 'validation uniqueness error adding a dwelling' do
+    login
+    development = create(:development)
+    create(:dwelling, development: development, reference_id: 'A10001')
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage dwellings'
+    click_link 'Add a new dwelling'
+    select 'open', from: 'Tenure'
+    fill_in 'Reference ID', with: 'A10001'
+    fill_in 'Number of habitable rooms', with: 2
+    fill_in 'Number of bedrooms', with: 1
+    click_button 'Add dwelling'
+    expect(page).to have_content('Reference ID has already been taken')
   end
 
   scenario 'successfully adding a dwelling to an agreed development' do


### PR DESCRIPTION
Ensure that we don't allow the creation of multiple dwellings within a development that have the same reference IDs.

Had to tweak the factories and some other tests to support this.