### PR TITLE
development page formatting

### DIFF
--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -42,7 +42,7 @@
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            Address
+            Site address
           %dd.govuk-summary-list__value
             %p.govuk-body= @development.site_address
           %dd.govuk-summary-list__actions

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -42,16 +42,6 @@
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
-            Proposal
-          %dd.govuk-summary-list__value
-            %p.govuk-body= @development.proposal
-          %dd.govuk-summary-list__actions
-            = link_to edit_development_path(@development), class: "govuk-link" do
-              Edit
-              %span.govuk-visually-hidden proposal
-
-        .govuk-summary-list__row
-          %dt.govuk-summary-list__key
             Address
           %dd.govuk-summary-list__value
             %p.govuk-body= @development.site_address
@@ -59,6 +49,16 @@
             = link_to edit_development_path(@development), class: "govuk-link" do
               Edit
               %span.govuk-visually-hidden address
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
+            Proposal
+          %dd.govuk-summary-list__value
+            %p.govuk-body= @development.proposal
+          %dd.govuk-summary-list__actions
+            = link_to edit_development_path(@development), class: "govuk-link" do
+              Edit
+              %span.govuk-visually-hidden proposal
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key


### PR DESCRIPTION
- change 'Address' to 'Site address'
- 'Site address' always comes before  'Proposal'

<img width="1066" alt="Screenshot 2019-11-20 at 16 11 41" src="https://user-images.githubusercontent.com/822507/69256023-b78f6880-0bb0-11ea-9dbc-8c96ff33f9f4.png">
