### PR TITLE
Feature/multiple planning applications

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -10,6 +10,7 @@ class DevelopmentsController < ApplicationController
 
   def new
     @development = Development.new
+    @development.planning_applications.build
   end
 
   def create
@@ -94,7 +95,14 @@ class DevelopmentsController < ApplicationController
   private
 
   def development_params
-    params.require(:development).permit(:name, :application_number, :site_address, :proposal, :audit_comment)
+    params.require(:development).permit(
+      :name,
+      :application_number,
+      :site_address,
+      :proposal,
+      :audit_comment,
+      planning_applications_attributes: [:application_number]
+    )
   end
 
   def completion_response_params

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -19,6 +19,20 @@ class PlanningApplicationsController < ApplicationController
     end
   end
 
+  def edit
+    @planning_application = @development.planning_applications.find(params[:id])
+  end
+
+  def update
+    @planning_application = @development.planning_applications.find(params[:id])
+    if @planning_application.update(planning_application_params)
+      flash[:notice] = 'Planning application successfully saved'
+      redirect_to development_planning_applications_path(@development)
+    else
+      render action: :edit
+    end
+  end
+
   private
 
   def find_development

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -33,6 +33,13 @@ class PlanningApplicationsController < ApplicationController
     end
   end
 
+  def destroy
+    @planning_application = @development.planning_applications.find(params[:id])
+    @planning_application.destroy!
+    flash[:notice] = 'Planning application deleted'
+    redirect_to development_planning_applications_path(@development)
+  end
+
   private
 
   def find_development

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -1,0 +1,31 @@
+class PlanningApplicationsController < ApplicationController
+  before_action :find_development
+
+  def index
+    @planning_applications = @development.planning_applications
+  end
+
+  def new
+    @planning_application = @development.planning_applications.build
+  end
+
+  def create
+    @planning_application = @development.planning_applications.build(planning_application_params)
+    if @planning_application.save
+      flash[:notice] = 'Planning application successfully added'
+      redirect_to development_planning_applications_path(@development)
+    else
+      render action: :new
+    end
+  end
+
+  private
+
+  def find_development
+    @development = Development.find(params[:development_id])
+  end
+
+  def planning_application_params
+    params.require(:planning_application).permit(:application_number)
+  end
+end

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -58,6 +58,10 @@ class Development < ApplicationRecord
     dwellings.within_s106.find { |dwelling| dwelling.address.blank? || dwelling.registered_provider.blank? }.blank?
   end
 
+  def primary_application_number
+    planning_applications.first.application_number
+  end
+
   private
 
   def set_developer_access_key

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -3,7 +3,7 @@ class Development < ApplicationRecord
   has_many :dwellings, dependent: :destroy
   accepts_nested_attributes_for :dwellings, update_only: true
 
-  validates :application_number, presence: true
+  validates :planning_applications, presence: true
   validates :state, presence: true
   validates :developer_access_key, presence: true
 

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -1,5 +1,6 @@
 class Development < ApplicationRecord
   has_many :planning_applications, dependent: :destroy
+  accepts_nested_attributes_for :planning_applications
   has_many :dwellings, dependent: :destroy
   accepts_nested_attributes_for :dwellings, update_only: true
 

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -37,9 +37,10 @@ class Development < ApplicationRecord
 
   include PgSearch::Model
   pg_search_scope :search,
-                  against: %i[application_number proposal site_address],
+                  against: %i[proposal site_address],
                   associated_against: {
                     dwellings: [:address],
+                    planning_applications: [:application_number],
                   }
 
   def audit_changes?

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -1,4 +1,5 @@
 class Development < ApplicationRecord
+  has_many :planning_applications, dependent: :destroy
   has_many :dwellings, dependent: :destroy
   accepts_nested_attributes_for :dwellings, update_only: true
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1,0 +1,4 @@
+class PlanningApplication < ApplicationRecord
+  belongs_to :development
+  validates :application_number, presence: true
+end

--- a/app/views/developments/_form.html.haml
+++ b/app/views/developments/_form.html.haml
@@ -2,9 +2,6 @@
   = f.input :name, input_html: { class: "govuk-input" }
 
 .govuk-form-group
-  = f.input :application_number, input_html: { class: "govuk-input govuk-input--width-10" }
-
-.govuk-form-group
   = f.input :site_address
 
 .govuk-form-group

--- a/app/views/developments/agree_confirmation.html.haml
+++ b/app/views/developments/agree_confirmation.html.haml
@@ -1,10 +1,10 @@
-- content_for(:page_title) { page_title("Mark development #{@development.application_number} as agreed") }
+- content_for(:page_title) { page_title("Mark development #{@development.primary_application_number} as agreed") }
 
 .govuk-width-container
   = link_to "Back to development", developments_path, class: "govuk-back-link"
   .govuk-grid-row
     .govuk-grid-column-full-from-desktop
-      %h1.govuk-heading-l Mark development #{@development.application_number} as agreed
+      %h1.govuk-heading-l Mark development #{@development.primary_application_number} as agreed
 
       .govuk-warning-text
         %span.govuk-warning-text__icon{"aria-hidden" => "true"} !

--- a/app/views/developments/complete_confirmation.html.haml
+++ b/app/views/developments/complete_confirmation.html.haml
@@ -1,10 +1,10 @@
-- content_for(:page_title) { page_title("Mark development #{@development.application_number} as completed") }
+- content_for(:page_title) { page_title("Mark development #{@development.primary_application_number} as completed") }
 
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"
   .govuk-grid-row
     .govuk-grid-column-full-from-desktop
-      %h1.govuk-heading-l Mark development #{@development.application_number} as completed
+      %h1.govuk-heading-l Mark development #{@development.primary_application_number} as completed
 
       .govuk-warning-text
         %span.govuk-warning-text__icon{"aria-hidden" => "true"} !

--- a/app/views/developments/completion_response_form.html.haml
+++ b/app/views/developments/completion_response_form.html.haml
@@ -1,7 +1,7 @@
 .govuk-width-container
   .govuk-grid-row
     .govuk-grid-column-full
-      %span.govuk-caption-xl Development #{@development.application_number}
+      %span.govuk-caption-xl Development #{@development.primary_application_number}
       %h1.govuk-heading-xl Complete your development information
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/developments/edit.html.haml
+++ b/app/views/developments/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for(:page_title) { @development.errors.any? ? page_title("Errors on page - Edit development #{@development.application_number}") : page_title("Edit development #{@development.application_number}") }
+- content_for(:page_title) { @development.errors.any? ? page_title("Errors on page - Edit development #{@development.primary_application_number}") : page_title("Edit development #{@development.primary_application_number}") }
 
 .govuk-width-container
   = link_to "Back to development", development_path(@development), class: "govuk-back-link"

--- a/app/views/developments/index.html.haml
+++ b/app/views/developments/index.html.haml
@@ -24,7 +24,7 @@
     %tbody.govuk-table__body
       - @developments.each do |development|
         %tr.govuk-table__row
-          %th.govuk-table__header{scope: "row"}= link_to development.application_number, development_path(development), class: "govuk-link", "aria-label": "view development #{development.application_number}"
+          %th.govuk-table__header{scope: "row"}= link_to development.primary_application_number, development_path(development), class: "govuk-link", "aria-label": "view development #{development.primary_application_number}"
           %td.govuk-table__cell= development.site_address
           %td.govuk-table__cell= development.proposal
           %td.govuk-table__cell

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -14,5 +14,9 @@
           .govuk-grid-column-two-thirds-from-desktop
             = simple_form_for @development do |f|
               = render partial: 'form', locals: {f: f}
+              = f.fields_for :planning_applications do |planning_application_form|
+                .govuk-form-group
+                  %p Developments must have at least one planning application. You can add more later.
+                  = planning_application_form.input :application_number, input_html: { class: "govuk-input govuk-input--width-10" }
               .govuk-form-group
                 = f.submit t('buttons.submit'), class: "govuk-button govuk-!-margin-right-1"

--- a/app/views/developments/new.html.haml
+++ b/app/views/developments/new.html.haml
@@ -15,8 +15,12 @@
             = simple_form_for @development do |f|
               = render partial: 'form', locals: {f: f}
               = f.fields_for :planning_applications do |planning_application_form|
+                .govuk-warning-text
+                  %span.govuk-warning-text__icon{"aria-hidden" => "true"} !
+                  %strong.govuk-warning-text__text
+                    %span.govuk-warning-text__assistive Warning
+                    Developments must have at least one planning application. You can add more later.
                 .govuk-form-group
-                  %p Developments must have at least one planning application. You can add more later.
                   = planning_application_form.input :application_number, input_html: { class: "govuk-input govuk-input--width-10" }
               .govuk-form-group
                 = f.submit t('buttons.submit'), class: "govuk-button govuk-!-margin-right-1"

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -52,6 +52,16 @@
 
         .govuk-summary-list__row
           %dt.govuk-summary-list__key
+            Planning Applications
+          %dd.govuk-summary-list__value
+            %p.govuk-body= @development.planning_applications.collect(&:application_number).join(', ')
+          %dd.govuk-summary-list__actions
+            = link_to development_planning_applications_path(@development), class: "govuk-link" do
+              Manage
+              %span.govuk-visually-hidden planning applications
+
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key
             Proposal
           %dd.govuk-summary-list__value
             %p.govuk-body= @development.proposal

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -1,10 +1,10 @@
-- content_for(:page_title) { page_title("Development " + @development.application_number) }
+- content_for(:page_title) { page_title("Development " + @development.primary_application_number) }
 
 .govuk-width-container
   = link_to "Back to all developments", developments_path, class: "govuk-back-link"
   .govuk-grid-row
     .govuk-grid-column-full-from-desktop
-      %h1.govuk-heading-xl Development #{@development.application_number}
+      %h1.govuk-heading-xl Development #{@development.primary_application_number}
 
       - if @development.completion_response_needed?
         = render 'developer_response_required'

--- a/app/views/developments/start_confirmation.html.haml
+++ b/app/views/developments/start_confirmation.html.haml
@@ -1,10 +1,10 @@
-- content_for(:page_title) { page_title("Mark development #{@development.application_number} as agreed") }
+- content_for(:page_title) { page_title("Mark development #{@development.primary_application_number} as agreed") }
 
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"
   .govuk-grid-row
     .govuk-grid-column-full-from-desktop
-      %h1.govuk-heading-l Mark development #{@development.application_number} as started
+      %h1.govuk-heading-l Mark development #{@development.primary_application_number} as started
 
       = form_for @development, url: start_development_path(@development) do |form|
         = form.submit 'Mark as started', class: "govuk-button"

--- a/app/views/dwellings/index.html.haml
+++ b/app/views/dwellings/index.html.haml
@@ -1,11 +1,11 @@
-- content_for(:page_title) { @dwelling.errors.any? ? page_title("Errors on page - Dwellings for " + @development.application_number) : page_title("Dwellings for " + @development.application_number) }
+- content_for(:page_title) { @dwelling.errors.any? ? page_title("Errors on page - Dwellings for " + @development.primary_application_number) : page_title("Dwellings for " + @development.primary_application_number) }
 
 .govuk-width-container
   = link_to "Back to development", development_path(@development), class: "govuk-back-link"
 
   .govuk-grid-row
     .govuk-grid-column-full
-      %h1.govuk-heading-xl Dwellings for #{@development.application_number}
+      %h1.govuk-heading-xl Dwellings for #{@development.primary_application_number}
 
       = link_to 'Add a new dwelling', new_development_dwelling_path, class: 'govuk-button' unless @development.completed?
 

--- a/app/views/planning_applications/_fields.html.haml
+++ b/app/views/planning_applications/_fields.html.haml
@@ -1,0 +1,2 @@
+.govuk-form-group
+  = form.input :application_number, input_html: { class: "govuk-input govuk-input--width-5" }

--- a/app/views/planning_applications/edit.html.haml
+++ b/app/views/planning_applications/edit.html.haml
@@ -16,4 +16,8 @@
         = simple_form_for([@development, @planning_application], method: :delete) do |form|
           %p= form.submit 'Delete planning application', data: {confirm: 'Are you sure?'}, class: "govuk-button govuk-button--warning"
       - else
-        %p You cannot delete the only planning application.
+        .govuk-warning-text
+          %span.govuk-warning-text__icon{"aria-hidden" => "true"} !
+          %strong.govuk-warning-text__text
+            %span.govuk-warning-text__assistive Warning
+            You cannot delete the only planning application.

--- a/app/views/planning_applications/edit.html.haml
+++ b/app/views/planning_applications/edit.html.haml
@@ -11,3 +11,9 @@
       = simple_form_for([@development, @planning_application]) do |form|
         = render partial: 'fields', locals: { form: form }
         = form.submit 'Save planning application', class: "govuk-button govuk-!-margin-right-1"
+
+      - if @development.planning_applications.count > 1
+        = simple_form_for([@development, @planning_application], method: :delete) do |form|
+          %p= form.submit 'Delete planning application', data: {confirm: 'Are you sure?'}, class: "govuk-button govuk-button--warning"
+      - else
+        %p You cannot delete the only planning application.

--- a/app/views/planning_applications/edit.html.haml
+++ b/app/views/planning_applications/edit.html.haml
@@ -1,0 +1,13 @@
+- content_for(:page_title) { @planning_application.errors.any? ? page_title('Errors on page - Edit planning application') : page_title('Edit planning application') }
+
+.govuk-width-container
+  = link_to "Back to planning applications", development_planning_applications_path(@development), class: "govuk-back-link"
+
+  = render partial: 'partials/error_block', locals: { record: @planning_application }
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl Edit planning application
+
+      = simple_form_for([@development, @planning_application]) do |form|
+        = render partial: 'fields', locals: { form: form }
+        = form.submit 'Save planning application', class: "govuk-button govuk-!-margin-right-1"

--- a/app/views/planning_applications/index.html.haml
+++ b/app/views/planning_applications/index.html.haml
@@ -1,0 +1,24 @@
+- content_for(:page_title) { page_title("Planning applications for " + @development.primary_application_number) }
+
+.govuk-width-container
+  = link_to "Back to development", development_path(@development), class: "govuk-back-link"
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %h1.govuk-heading-xl Planning Applications for #{@development.primary_application_number}
+
+      = link_to 'Add a new planning application', new_development_planning_application_path, class: 'govuk-button'
+
+      .table-scrollable
+        %table.govuk-table
+          %caption.govuk-table__caption.govuk-visually-hidden Planning Applications
+          %thead.govuk-table__head
+            %tr.govuk-table__row
+              %th{class: "govuk-table__header", scope: "col"} Application Number
+              %th{class: "govuk-table__header", scope: "col"} Actions
+
+          %tbody.govuk-table__body
+            -@development.planning_applications.each do |planning_application|
+              %tr.govuk-table__row
+                %th.govuk-table__header{scope: "row"}= planning_application.application_number
+                %td.govuk-table__cell= link_to 'Edit', edit_development_planning_application_path(@development, planning_application), class: "govuk-link", "aria-label": "Edit dwelling #{planning_application.application_number}"

--- a/app/views/planning_applications/new.html.haml
+++ b/app/views/planning_applications/new.html.haml
@@ -1,0 +1,13 @@
+.govuk-width-container
+  = link_to "Back to planning applications", development_planning_applications_path(@development), class: "govuk-back-link"
+
+  = render partial: 'partials/error_block', locals: { record: @planning_application }
+
+  .govuk-grid-row
+    .govuk-grid-column-full
+
+      %h1.govuk-heading-xl Add a dwelling
+
+      = simple_form_for([@development, @planning_application]) do |form|
+        = render partial: 'fields', locals: { form: form }
+        = form.submit 'Add planning application', class: "govuk-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         get :delete
       end
     end
+    resources :planning_applications
     member do
       get :agree_confirmation
       patch :agree

--- a/db/migrate/20191120170227_create_planning_applications.rb
+++ b/db/migrate/20191120170227_create_planning_applications.rb
@@ -1,0 +1,10 @@
+class CreatePlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :planning_applications do |t|
+      t.string :application_number
+      t.references :development, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_094657) do
+ActiveRecord::Schema.define(version: 2019_11_20_170227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,14 @@ ActiveRecord::Schema.define(version: 2019_11_13_094657) do
     t.index ["registered_provider_id"], name: "index_dwellings_on_registered_provider_id"
   end
 
+  create_table "planning_applications", force: :cascade do |t|
+    t.string "application_number"
+    t.bigint "development_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["development_id"], name: "index_planning_applications_on_development_id"
+  end
+
   create_table "registered_providers", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
@@ -79,4 +87,5 @@ ActiveRecord::Schema.define(version: 2019_11_13_094657) do
 
   add_foreign_key "dwellings", "developments"
   add_foreign_key "dwellings", "registered_providers"
+  add_foreign_key "planning_applications", "developments"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ Development.without_auditing do
       state = %w[draft agreed started completed].sample
 
       development = Development.create!(
-        planning_applications: [PlanningApplication.create!(application_number: app_number)],
+        planning_applications: [PlanningApplication.new(application_number: app_number)],
         site_address: address,
         proposal: proposal,
         state: state

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,10 @@ Development.without_auditing do
       state = %w[draft agreed started completed].sample
 
       development = Development.create!(
-        application_number: app_number, site_address: address, proposal: proposal, state: state
+        planning_applications: [PlanningApplication.create!(application_number: app_number)],
+        site_address: address,
+        proposal: proposal,
+        state: state
       )
 
       Random.rand(3...12).times do |i|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -37,5 +37,15 @@ FactoryBot.define do
         dwelling.planning_applications << build(:planning_application, development: nil)
       end
     end
+
+    factory :development_with_number do
+      transient do
+        application_number { 'AP/2019/1234' }
+        planning_applications_count { 0 }
+      end
+      after(:build) do |dwelling, evaluator|
+        dwelling.planning_applications << build(:planning_application, development: nil, application_number: evaluator.application_number)
+      end
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
+  factory :planning_application do
+    application_number { "MyString" }
+    development { nil }
+  end
+
   factory :registered_provider do
     name { 'RPName' }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :planning_application do
-    application_number { "MyString" }
-    development { nil }
+    application_number { 'AP/2019/1234' }
+    development
   end
 
   factory :registered_provider do
@@ -24,9 +24,18 @@ FactoryBot.define do
 
   factory :development do
     name { 'Development name' }
-    application_number { 'AP/2019/1234' }
     site_address { '1 Site Address, London, SE1 1AA' }
     proposal { 'Build a building' }
     state { 'draft' }
+
+    transient do
+      planning_applications_count { 1 }
+    end
+
+    after(:build) do |dwelling, evaluator|
+      evaluator.planning_applications_count.times do
+        dwelling.planning_applications << build(:planning_application, development: nil)
+      end
+    end
   end
 end

--- a/spec/features/creating_planning_applications_spec.rb
+++ b/spec/features/creating_planning_applications_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Creating planning applications', type: :feature do
+  scenario 'successfully adding a planning application to a new development' do
+    login
+    development = create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    click_link 'Add a new planning application'
+    fill_in 'Application number', with: 'A111'
+    click_button 'Add planning application'
+    expect(page).to have_content('Planning application successfully added')
+    development.reload
+    planning_application = development.planning_applications.last
+    expect(planning_application.application_number).to eq('A111')
+  end
+
+  scenario 'validation presence error adding a planning application' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    click_link 'Add a new planning application'
+    fill_in 'Application number', with: ''
+    click_button 'Add planning application'
+    expect(page).to have_content("Application number can't be blank")
+  end
+end

--- a/spec/features/deleting_planning_applications_spec.rb
+++ b/spec/features/deleting_planning_applications_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Deleting planning applications', type: :feature do
+  scenario 'successfully' do
+    login
+    development = create(:development)
+    planning_application = create(:planning_application, development: development, application_number: 'AP/2019/4444')
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    within(:xpath, "//th[text() = '#{planning_application.application_number}']/parent::tr") do
+      click_link 'Edit'
+    end
+    click_button 'Delete planning application'
+    expect(page).to have_content('Planning application deleted')
+    development.reload
+    expect(development.planning_applications.count).to eq(1)
+  end
+
+  scenario 'when only one planning application exists on development' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    click_link 'Edit'
+    expect(page).to_not have_content('Delete planning application')
+    expect(page).to have_content('You cannot delete the only planning application')
+  end
+end

--- a/spec/features/editing_developments_spec.rb
+++ b/spec/features/editing_developments_spec.rb
@@ -13,18 +13,6 @@ RSpec.feature 'Editing a development core details', type: :feature do
     expect(page).to have_text('New development name')
   end
 
-  scenario 'successfully - application number' do
-    login
-    create(:development)
-    visit developments_path
-    click_link 'AP/2019/1234'
-    find('a', text: 'Edit proposal', visible: false).click
-    fill_in 'Application number', with: 'AP/2019/1235'
-    click_button 'Save and continue'
-    expect(page).to have_text('Development successfully saved')
-    expect(page).to have_text('AP/2019/1235')
-  end
-
   scenario 'successfully - site address' do
     login
     create(:development)
@@ -77,19 +65,6 @@ RSpec.feature 'Editing a development core details', type: :feature do
       expect(page).to have_content('Testing changelog')
       expect(page).to have_content(user.email)
     end
-  end
-
-  scenario 'with validation error' do
-    login
-    create(:development)
-    visit developments_path
-    click_link 'AP/2019/1234'
-    find('a', text: 'Edit proposal', visible: false).click
-    fill_in 'Application number', with: ''
-    fill_in 'Site address', with: ''
-    fill_in 'Proposal', with: ''
-    click_button 'Save and continue'
-    expect(page).to have_content("Application number can't be blank")
   end
 
   scenario 'no changelog when required' do

--- a/spec/features/editing_planning_applications_spec.rb
+++ b/spec/features/editing_planning_applications_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing planning applications', type: :feature do
+  scenario 'successfully editing a planning application on a new development' do
+    login
+    development = create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    click_link 'Edit'
+    fill_in 'Application number', with: 'A1001'
+    click_button 'Save planning application'
+    expect(page).to have_content('Planning application successfully saved')
+    development.reload
+    planning_application = development.planning_applications.last
+    expect(planning_application.application_number).to eq('A1001')
+  end
+
+  scenario 'validation presence error editing a dwelling' do
+    login
+    create(:development)
+    visit developments_path
+    click_link 'AP/2019/1234'
+    click_link 'Manage planning applications'
+    click_link 'Edit'
+    fill_in 'Application number', with: ''
+    click_button 'Save planning application'
+    expect(page).to have_content("Application number can't be blank")
+  end
+end

--- a/spec/features/searching_developments_spec.rb
+++ b/spec/features/searching_developments_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Searching developments', type: :feature do
   before do
-    development1 = create(:development, application_number: 'APP1', proposal: 'Build development', site_address: '1 Old Street')
-    create(:development, application_number: 'APP2', proposal: 'Build houses', site_address: '1 New Street')
+    development1 = create(:development_with_number, application_number: 'APP1', proposal: 'Build development', site_address: '1 Old Street')
+    create(:development_with_number, application_number: 'APP2', proposal: 'Build houses', site_address: '1 New Street')
     create(:dwelling, development: development1, address: 'Flat 1, Flower House, SE1 1AA')
   end
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PlanningApplication, type: :model do
+end


### PR DESCRIPTION

Allows a development to have multiple planning applications. Lots more information in the commit messages.

Once this has merged, your database will then have invalid data in it (Developments without a planning application). To fix this, either `rake db:reset` to reset your database and run the seeds, or run the following in the console:

`Development.all.each {|d| d.planning_applications.create!(application_number: d.application_number) }`