### PR TITLE
Add 'none' option to planning application select in changelog

### DIFF
--- a/app/views/developments/_form.html.haml
+++ b/app/views/developments/_form.html.haml
@@ -11,4 +11,4 @@
   .govuk-form-group
     = f.input :audit_comment, label: 'Reason for changes to legal agreement'
   .govuk-form-group
-    = f.input :audit_planning_application_id, label: 'Planning application change was agreed', collection: f.object.planning_applications.collect {|pa| [pa.application_number, pa.id]}
+    = f.input :audit_planning_application_id, label: 'Planning application change was agreed', collection: f.object.planning_applications.collect {|pa| [pa.application_number, pa.id]}, wrapper: :select, include_blank: 'None'

--- a/app/views/dwellings/_fields.html.haml
+++ b/app/views/dwellings/_fields.html.haml
@@ -10,4 +10,4 @@
   .govuk-form-group
     = form.input :audit_comment, label: 'Reason for changes to legal agreement', required: true
   .govuk-form-group
-    = form.input :audit_planning_application_id, label: 'Planning application this change was agreed in', collection: form.object.development.planning_applications.collect {|pa| [pa.application_number, pa.id]}, selected: form.object.development.planning_applications.first, wrapper: :select
+    = form.input :audit_planning_application_id, label: 'Planning application this change was agreed in', collection: form.object.development.planning_applications.collect {|pa| [pa.application_number, pa.id]}, wrapper: :select, include_blank: 'None'


### PR DESCRIPTION
- The development edit form did not have `wrapper: select` set as an option
- The dwelling form had the first planning application always selected, removing the option for blank. This field is not mandatory, and they can choose none (if it's just a typo)
- Label the blank option as 'none' to be more explicit that this is what is being chosen

Questions:

- is "none" a good enough select text for nil?
- We have 'This value is optional' help text, but is that not implied by having a 'none' option?