### PR TITLE
adds gov.uk-style focus styles for subnavigation links

### DIFF
--- a/app/assets/stylesheets/components/_subnavigation.scss
+++ b/app/assets/stylesheets/components/_subnavigation.scss
@@ -22,6 +22,12 @@
       &:focus {
         outline: 0;
       }
+      &:focus {
+        border-color: $govuk-focus-colour;
+        background-color: $govuk-focus-colour;
+        color: $govuk-text-colour;
+        box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+      }
     }
     &.active a,
     &.active a:hover {


### PR DESCRIPTION
Important for a11y.

Before:<img width="735" alt="before" src="https://user-images.githubusercontent.com/822507/69954392-18913780-14f3-11ea-8f97-d2081d7b2063.png">
After:<img width="726" alt="after" src="https://user-images.githubusercontent.com/822507/69954395-19c26480-14f3-11ea-89f0-cae295b4515e.png">
