### PR TITLE
status descriptions on confirmation pages

### DIFF
--- a/app/assets/stylesheets/components/_state-labels.scss
+++ b/app/assets/stylesheets/components/_state-labels.scss
@@ -17,3 +17,8 @@
   background-color: govuk-colour('pink');
   color: govuk-colour('white');
 }
+
+.govuk-tag-expired {
+  background-color: govuk-colour('red');
+  color: govuk-colour('white');
+}

--- a/app/views/developments/agree_confirmation.html.haml
+++ b/app/views/developments/agree_confirmation.html.haml
@@ -3,8 +3,10 @@
 .govuk-width-container
   = link_to "Back to development", developments_path, class: "govuk-back-link"
   .govuk-grid-row
-    .govuk-grid-column-full-from-desktop
+    .govuk-grid-column-two-thirds-from-desktop
       %h1.govuk-heading-l Mark development #{@development.primary_application_number} as agreed
+
+      = render 'partials/statuses'
 
       .govuk-warning-text
         %span.govuk-warning-text__icon{"aria-hidden" => "true"} !

--- a/app/views/developments/complete_confirmation.html.haml
+++ b/app/views/developments/complete_confirmation.html.haml
@@ -3,8 +3,10 @@
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"
   .govuk-grid-row
-    .govuk-grid-column-full-from-desktop
+    .govuk-grid-column-two-thirds-from-desktop
       %h1.govuk-heading-l Mark development #{@development.primary_application_number} as completed
+
+      = render 'partials/statuses'
 
       .govuk-warning-text
         %span.govuk-warning-text__icon{"aria-hidden" => "true"} !

--- a/app/views/developments/start_confirmation.html.haml
+++ b/app/views/developments/start_confirmation.html.haml
@@ -3,8 +3,10 @@
 .govuk-width-container
   = link_to "Back", developments_path, class: "govuk-back-link"
   .govuk-grid-row
-    .govuk-grid-column-full-from-desktop
+    .govuk-grid-column-two-thirds-from-desktop
       %h1.govuk-heading-l Mark development #{@development.primary_application_number} as started
+
+      = render 'partials/statuses'
 
       = form_for @development, url: start_development_path(@development) do |form|
         = form.submit 'Mark as started', class: "govuk-button"

--- a/app/views/partials/_statuses.haml
+++ b/app/views/partials/_statuses.haml
@@ -1,0 +1,34 @@
+%details.govuk-details{"data-module" => "govuk-details"}
+  %summary.govuk-details__summary
+    %span.govuk-details__summary-text
+      What do the statuses mean?
+  .govuk-details__text
+
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-draft"} Draft
+      %dd.govuk-summary-list__value
+        %p This is a new record of a development on the system.
+        %p This record can be freely amended or deleted until the status is changed to Agreed, when the S106 and planning permission is granted and the schedule of accommodation is provided by the developer.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-agreed"} Agreed
+      %dd.govuk-summary-list__value
+        %p The S106 and planning permission has been granted and a schedule of accommodation has been provided by the developer.
+        %p The S106 has been signed and planning permission has been granted. A schedule of accommodation was submitted which outlines the affordable housing provision. Any changes made to the affordable housing provision from this point will be noted on the Change Log.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-started"} Started
+      %dd.govuk-summary-list__value
+        %p Building work has started on the development site. The first CIL payment has been received for this development and the development has commenced.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-completed"} Completed
+      %dd.govuk-summary-list__value
+        %p Building work has finished on the development site. The developer has requested Street Naming and Numbering for the development.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-expired"} Expired
+      %dd.govuk-summary-list__value
+        %p The planning permission has expired on this site.
+        %p The planning determination date shows that this development received planning approval more than 3 years ago and the development has not been started.


### PR DESCRIPTION
-  when a user goes to change the status of a development, they can access detailed descriptions of all the statuses in a [`<details>` element pattern from the GOV.UK design system.](https://design-system.service.gov.uk/components/details/)

<img width="787" alt="collapsed" src="https://user-images.githubusercontent.com/822507/69957712-192dcc00-14fb-11ea-93c4-b76d11c07d78.png">
<img width="940" alt="open" src="https://user-images.githubusercontent.com/822507/69957719-1af78f80-14fb-11ea-9763-ab9152fd32c9.png">
