### PR TITLE
Feature/unconfirmed complete status

### DIFF
--- a/app/assets/stylesheets/components/_state-labels.scss
+++ b/app/assets/stylesheets/components/_state-labels.scss
@@ -18,8 +18,13 @@
   color: govuk-colour('white');
 }
 
+.govuk-tag-partially_confirmed_completed {
+  background-color: govuk-colour("light-purple");
+  color: govuk-colour('white');
+}
+
 .govuk-tag-confirmed_completed {
-  background-color: govuk-colour("light-pink");
+  background-color: govuk-colour("orange");
   color: govuk-colour('white');
 }
 

--- a/app/assets/stylesheets/components/_state-labels.scss
+++ b/app/assets/stylesheets/components/_state-labels.scss
@@ -13,8 +13,13 @@
   color: govuk-colour('white');
 }
 
-.govuk-tag-completed {
+.govuk-tag-unconfirmed_completed {
   background-color: govuk-colour('pink');
+  color: govuk-colour('white');
+}
+
+.govuk-tag-confirmed_completed {
+  background-color: govuk-colour("light-pink");
   color: govuk-colour('white');
 }
 

--- a/app/assets/stylesheets/components/govuk-overrides.scss
+++ b/app/assets/stylesheets/components/govuk-overrides.scss
@@ -23,3 +23,7 @@ $highlight-colour: #D6CC2F;
     max-width: 140px;
   }
 }
+
+.govuk-summary-list__value {
+  vertical-align: top;
+}

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -79,22 +79,23 @@ class DevelopmentsController < ApplicationController
 
   def complete
     @development = Development.find(params[:id])
-    @development.complete!
+    @development.unconfirmed_complete!
     flash[:notice] = 'Development marked as completed'
     redirect_to development_path(@development)
   end
 
   def completion_response_form
-    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak], state: 'completed')
+    find_development_for_completion_response
 
     render action: :completion_response if @development.completion_response_filled?
   end
 
   def completion_response
-    @development = Development.find_by!(id: params[:id], developer_access_key: params[:dak], state: 'completed')
+    find_development_for_completion_response
     @development.update!(completion_response_params)
     @development.reload
     if @development.completion_response_filled?
+      @development.confirmed_complete!
       render
     else
       flash[:notice] = 'Your changes have been saved. We still need more information from you'
@@ -103,6 +104,14 @@ class DevelopmentsController < ApplicationController
   end
 
   private
+
+  def find_development_for_completion_response
+    @development = Development.find_by!(
+      id: params[:id],
+      developer_access_key: params[:dak],
+      state: 'unconfirmed_completed'
+    )
+  end
 
   def development_params
     params.require(:development).permit(

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -23,7 +23,7 @@ class Development < ApplicationRecord
   include AASM
   aasm column: 'state' do
     state :draft, initial: true
-    state :agreed, :started, :completed
+    state :agreed, :started, :unconfirmed_completed, :confirmed_completed
 
     event :agree do
       transitions from: :draft, to: :agreed
@@ -33,8 +33,12 @@ class Development < ApplicationRecord
       transitions from: :agreed, to: :started
     end
 
-    event :complete do
-      transitions from: :started, to: :completed
+    event :unconfirmed_complete do
+      transitions from: :started, to: :unconfirmed_completed
+    end
+
+    event :confirmed_complete do
+      transitions from: :unconfirmed_completed, to: :confirmed_completed
     end
   end
 
@@ -51,13 +55,13 @@ class Development < ApplicationRecord
   end
 
   def completion_response_needed?
-    return false if state != 'completed'
+    return false if state != 'unconfirmed_completed'
 
     !completion_response_filled?
   end
 
   def completion_response_filled?
-    return false if state != 'completed'
+    return false if state != 'unconfirmed_completed'
 
     dwellings.within_s106.find { |dwelling| dwelling.address.blank? || dwelling.registered_provider.blank? }.blank?
   end

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -70,6 +70,10 @@ class Development < ApplicationRecord
     planning_applications.first.application_number
   end
 
+  def completed?
+    unconfirmed_completed? || confirmed_completed?
+  end
+
   private
 
   def set_developer_access_key

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -26,9 +26,9 @@
     %section#development-details.govuk-tabs__panel
       %h2.govuk-heading-l Development details
 
-      - if @development.completion_response_needed?
+      - if @development.unconfirmed_completed?
         = render 'developer_response_required'
-      - if @development.completion_response_filled?
+      - if @development.confirmed_completed?
         = render 'developer_response_given'
 
       %dl.govuk-summary-list{:class => "govuk-!-margin-bottom-9"}

--- a/app/views/partials/_statuses.haml
+++ b/app/views/partials/_statuses.haml
@@ -23,9 +23,22 @@
         %p Building work has started on the development site. The first CIL payment has been received for this development and the development has commenced.
     .govuk-summary-list__row
       %dt.govuk-summary-list__key
-        %span.govuk-tag{class: "govuk-tag-completed"} Completed
+        %span.govuk-tag{class: "govuk-tag-unconfirmed_completed"} Unconfirmed completed
       %dd.govuk-summary-list__value
-        %p Building work has finished on the development site. The developer has requested Street Naming and Numbering for the development.
+        %p Building work has finished on the development site.
+        %p The developer has requested Street Naming and Numbering for the development.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-partially_confirmed_completed"} Partially confirmed completed
+      %dd.govuk-summary-list__value
+        %p Development is completed and the affordable units and their addresses have been confirmed by the Developer.
+        %p The developer has responded to the Developer Completion Form, confirming the tenure types and providing addresses for the confirmed affordable units.
+    .govuk-summary-list__row
+      %dt.govuk-summary-list__key
+        %span.govuk-tag{class: "govuk-tag-confirmed_completed"} Confirmed completed
+      %dd.govuk-summary-list__value
+        %p A registered provider has verified that they have received the affordable units and confirmed their tenures.
+        %p The registered provider has responded to the RP Completion Form, providing their own internal identification numbers for the affordable units. They have also confirmed the tenure type.
     .govuk-summary-list__row
       %dt.govuk-summary-list__key
         %span.govuk-tag{class: "govuk-tag-expired"} Expired

--- a/spec/features/completing_a_development_spec.rb
+++ b/spec/features/completing_a_development_spec.rb
@@ -10,6 +10,6 @@ RSpec.feature 'Marking a development as completed', type: :feature do
     click_button 'Mark as completed'
     expect(page).to have_content 'Development marked as completed'
     development.reload
-    expect(development.state).to eq('completed')
+    expect(development.state).to eq('unconfirmed_completed')
   end
 end

--- a/spec/features/developer_completion_response_spec.rb
+++ b/spec/features/developer_completion_response_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
   before do
     @registered_provider1 = create(:registered_provider, name: 'RPOne')
     @registered_provider2 = create(:registered_provider, name: 'RPTwo')
-    @development = create(:development, state: 'completed')
+    @development = create(:development, state: 'unconfirmed_completed')
     Dwelling.without_auditing do
       create(:dwelling, development: @development, tenure: 'open')
       @intermediate_dwelling = create(:dwelling, development: @development, tenure: 'intermediate')
@@ -36,6 +36,9 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     expect(@intermediate_dwelling.registered_provider).to eq(@registered_provider1)
     expect(@social_dwelling.address).to eq('2 Newbuild House')
     expect(@social_dwelling.registered_provider).to eq(@registered_provider2)
+
+    @development.reload
+    expect(@development.state).to eq('confirmed_completed')
   end
 
   scenario 'successfully but incomplete' do
@@ -59,6 +62,9 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     @intermediate_dwelling.reload
     expect(@intermediate_dwelling.address).to eq('1 Newbuild House')
     expect(@intermediate_dwelling.registered_provider).to eq(@registered_provider1)
+
+    @development.reload
+    expect(@development.state).to eq('unconfirmed_completed')
   end
 
   scenario 'with wrong access key' do

--- a/spec/features/requesting_developer_completion_response_spec.rb
+++ b/spec/features/requesting_developer_completion_response_spec.rb
@@ -1,28 +1,22 @@
 require 'rails_helper'
 
 RSpec.feature 'Requesting a developer completion response', type: :feature do
-  scenario 'when development is completed and has incomplete dwelling' do
-    development = create(:development, state: 'completed')
-    Dwelling.without_auditing do
-      create(:dwelling, development: development, tenure: 'social', address: '')
-    end
+  scenario 'when development is unconfirmed_completed and has incomplete dwelling' do
+    development = create(:development, state: 'unconfirmed_completed')
     login
     click_link 'AP/2019/1234'
     expect(page).to have_content 'Developer completion response needed'
     expect(find_field('developer_response_url').value).to have_content(completion_response_form_development_path(development))
   end
 
-  scenario 'when development is completed and has complete dwellings' do
-    development = create(:development, state: 'completed')
-    Dwelling.without_auditing do
-      create(:dwelling, development: development, tenure: 'social', address: 'present', registered_provider: create(:registered_provider))
-    end
+  scenario 'when development is confirmed_completed' do
+    create(:development, state: 'confirmed_completed')
     login
     click_link 'AP/2019/1234'
     expect(page).to have_content 'The developer has responded with the full details for this development.'
   end
 
-  scenario 'when development is not completed' do
+  scenario 'when development is not unconfirmed_completed' do
     create(:development)
     login
     click_link 'AP/2019/1234'

--- a/spec/models/development_spec.rb
+++ b/spec/models/development_spec.rb
@@ -28,21 +28,21 @@ RSpec.describe Development, type: :model do
     let!(:dwelling) { create(:dwelling, development: development, tenure: 'intermediate') }
     let!(:open_dwelling) { create(:dwelling, development: development, tenure: 'open', address: '') }
 
-    it 'should be false if status is not completed' do
+    it 'should be false if status is not unconfirmed_completed' do
       development.update(state: 'draft')
       expect(development.completion_response_needed?).to eq(false)
     end
 
-    it 'should be true if status is completed and any dwellings do not have address or registered provider' do
-      development.update(state: 'completed')
+    it 'should be true if status is unconfirmed_completed and any dwellings do not have address or registered provider' do
+      development.update(state: 'unconfirmed_completed')
       dwelling.update(address: '', registered_provider: nil)
       development.reload
 
       expect(development.completion_response_needed?).to eq(true)
     end
 
-    it 'should be false if status is completed and all dwellings have address and registered provider' do
-      development.update(state: 'completed')
+    it 'should be false if status is unconfirmed_completed and all dwellings have address and registered provider' do
+      development.update(state: 'unconfirmed_completed')
       dwelling.update(address: 'present', registered_provider: create(:registered_provider))
       development.reload
 


### PR DESCRIPTION
Previously we just had a confirmed state, and then had a `completion_response_filled?` method that kind of worked as a semi-official additional state after that.

To simplify this, `confirmed` state has now gone, replaced by `unconfirmed_completed` and `confirmed_completed`,  moving between the former and letter once a developer has responded.

If you have existing data, then you might have some developments that are marked as `completed` which would now be invalid. If so, run the following in the console:

`Development.where(state: 'completed').each {|d| d.update!(state: 'unconfirmed_completed') }`