### PR TITLE
Feature/rp response form

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -104,11 +104,11 @@ class DevelopmentsController < ApplicationController
   end
 
   def rp_response_form
-    @development = Development.find_by!(id: params[:id], state: 'completed')
+    @development = Development.find_by!(id: params[:id], state: 'completed', rp_access_key: params[:rpak])
   end
 
   def rp_response
-    @development = Development.find_by!(id: params[:id], state: 'completed')
+    @development = Development.find_by!(id: params[:id], state: 'completed', rp_access_key: params[:rpak])
     @development.update!(rp_response_params)
   end
 

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -1,5 +1,5 @@
 class DevelopmentsController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[completion_response_form completion_response]
+  skip_before_action :authenticate_user!, only: %i[completion_response_form completion_response rp_response_form rp_response]
   def index
     @developments = if params.dig(:search, :q).present?
                       Development.search(params[:search][:q])
@@ -103,6 +103,15 @@ class DevelopmentsController < ApplicationController
     end
   end
 
+  def rp_response_form
+    @development = Development.find_by!(id: params[:id], state: 'completed')
+  end
+
+  def rp_response
+    @development = Development.find_by!(id: params[:id], state: 'completed')
+    @development.update!(rp_response_params)
+  end
+
   private
 
   def find_development_for_completion_response
@@ -128,5 +137,9 @@ class DevelopmentsController < ApplicationController
 
   def completion_response_params
     params.require(:development).permit(dwellings_attributes: %i[id address registered_provider_id])
+  end
+
+  def rp_response_params
+    params.require(:development).permit(dwellings_attributes: %i[id rp_internal_id])
   end
 end

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -25,7 +25,7 @@ class Development < ApplicationRecord
   include AASM
   aasm column: 'state' do
     state :draft, initial: true
-    state :agreed, :started, :unconfirmed_completed, :confirmed_completed
+    state :agreed, :started, :unconfirmed_completed, :partially_confirmed_completed, :confirmed_completed
 
     event :agree do
       transitions from: :draft, to: :agreed
@@ -39,8 +39,12 @@ class Development < ApplicationRecord
       transitions from: :started, to: :unconfirmed_completed
     end
 
+    event :partially_confirmed_complete do
+      transitions from: :unconfirmed_completed, to: :partially_confirmed_completed
+    end
+
     event :confirmed_complete do
-      transitions from: :unconfirmed_completed, to: :confirmed_completed
+      transitions from: :partially_confirmed_completed, to: :confirmed_completed
     end
   end
 

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -7,8 +7,10 @@ class Development < ApplicationRecord
   validates :planning_applications, presence: true
   validates :state, presence: true
   validates :developer_access_key, presence: true
+  validates :rp_access_key, presence: true
 
   before_validation :set_developer_access_key, on: :create
+  before_validation :set_rp_access_key, on: :create
 
   acts_as_gov_uk_date :agreed_on, :started_on
 
@@ -78,6 +80,10 @@ class Development < ApplicationRecord
 
   def set_developer_access_key
     self.developer_access_key = SecureRandom.urlsafe_base64(20)
+  end
+
+  def set_rp_access_key
+    self.rp_access_key = SecureRandom.urlsafe_base64(20)
   end
 
   def write_audit(attrs)

--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -7,7 +7,7 @@ class Dwelling < ApplicationRecord
     if: :audit_changes?,
     on: %i[create update destroy],
     comment_required: true,
-    except: %i[address registered_provider_id]
+    except: %i[address registered_provider_id rp_internal_id]
   )
 
   attr_accessor :audit_planning_application_id

--- a/app/views/developments/_developer_and_rp_response_given.haml
+++ b/app/views/developments/_developer_and_rp_response_given.haml
@@ -1,0 +1,2 @@
+.highlight{class: 'govuk-!-margin-bottom-6'}
+  %p.govuk-body{class: 'govuk-!-margin-bottom-0'} The developer and registered provider have responded with the full details for this development.

--- a/app/views/developments/_developer_response_given.haml
+++ b/app/views/developments/_developer_response_given.haml
@@ -1,2 +1,0 @@
-.highlight{class: 'govuk-!-margin-bottom-6'}
-  %p.govuk-body{class: 'govuk-!-margin-bottom-0'} The developer has responded with the full details for this development.

--- a/app/views/developments/_rp_response_required.haml
+++ b/app/views/developments/_rp_response_required.haml
@@ -1,0 +1,6 @@
+.highlight{class: 'govuk-!-margin-bottom-6'}
+  %h2.govuk-heading-s Registered Provider response needed
+  %p.govuk-body The developer has responded with the addresses and registered provider.
+  %p.govuk-body Copy and paste the URL below and send it to the registered provider. When they've filled out the form, you'll see the responses here.
+  %label.govuk-label{for: 'rp_response_url'} Regisered Provider response URL
+  %input{type: 'text', id: 'rp_response_url', class: 'govuk-input govuk-!-width-full', value: rp_response_form_development_url(@development, rpak: @development.rp_access_key)}

--- a/app/views/developments/rp_response.html.haml
+++ b/app/views/developments/rp_response.html.haml
@@ -1,0 +1,10 @@
+- content_for(:page_title) { page_title('Your development information has been submitted') }
+
+.govuk-width-container
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-panel.govuk-panel--confirmation
+        %h1.govuk-panel__title
+          Your development information has been submitted
+        .govuk-panel__body
+          Thank you!

--- a/app/views/developments/rp_response_form.html.haml
+++ b/app/views/developments/rp_response_form.html.haml
@@ -10,7 +10,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       = simple_form_for(@development, url: rp_response_development_path(@development)) do |form|
-        -# = hidden_field_tag :dak, @development.developer_access_key
+        = hidden_field_tag :rpak, @development.rp_access_key
         = form.fields_for :dwellings, @development.dwellings.within_s106 do |dwelling_form|
           .govuk-fieldset{class: 'govuk-!-margin-top-9 govuk-!-margin-bottom-9'}
             %legend.govuk-fieldset__legend.govuk-fieldset__legend--m

--- a/app/views/developments/rp_response_form.html.haml
+++ b/app/views/developments/rp_response_form.html.haml
@@ -1,0 +1,26 @@
+.govuk-width-container
+  .govuk-grid-row
+    .govuk-grid-column-full
+      %span.govuk-caption-xl Development #{@development.primary_application_number}
+      %h1.govuk-heading-xl Complete your development information
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %p.govuk-body-l We have been told that you have recieved the following dwellings. Please could you confirm that you have recieved them, and let us know your internal ID for these dwellings so we can ask you about them in the future.
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = simple_form_for(@development, url: rp_response_development_path(@development)) do |form|
+        -# = hidden_field_tag :dak, @development.developer_access_key
+        = form.fields_for :dwellings, @development.dwellings.within_s106 do |dwelling_form|
+          .govuk-fieldset{class: 'govuk-!-margin-top-9 govuk-!-margin-bottom-9'}
+            %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+              %h2.govuk-fieldset__heading= "Dwelling #{dwelling_form.object.id}"
+            %div{class: "dwelling_#{dwelling_form.object.id}"}
+              %p.govuk-body
+                Address: #{dwelling_form.object.address},
+                Tenure: #{dwelling_form.object.tenure.humanize},
+                Bedrooms: #{dwelling_form.object.bedrooms},
+                Habitable rooms: #{dwelling_form.object.habitable_rooms}
+              .govuk-form-group
+                = dwelling_form.input :rp_internal_id, required: 'true', label: 'Your ID'
+        = form.submit 'Submit response', class: 'govuk-button'

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -28,8 +28,10 @@
 
       - if @development.unconfirmed_completed?
         = render 'developer_response_required'
+      - if @development.partially_confirmed_completed?
+        = render 'rp_response_required'
       - if @development.confirmed_completed?
-        = render 'developer_response_given'
+        = render 'developer_and_rp_response_given'
 
       %dl.govuk-summary-list{:class => "govuk-!-margin-bottom-9"}
         .govuk-summary-list__row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
 
       get :completion_response_form
       patch :completion_response
+
+      get :rp_response_form
+      patch :rp_response
     end
   end
 

--- a/db/migrate/20191128114008_add_rp_internal_id_to_dwellings.rb
+++ b/db/migrate/20191128114008_add_rp_internal_id_to_dwellings.rb
@@ -1,0 +1,5 @@
+class AddRpInternalIdToDwellings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dwellings, :rp_internal_id, :string
+  end
+end

--- a/db/migrate/20191202141309_add_rp_access_key_to_developments.rb
+++ b/db/migrate/20191202141309_add_rp_access_key_to_developments.rb
@@ -1,0 +1,5 @@
+class AddRpAccessKeyToDevelopments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :developments, :rp_access_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_173904) do
     t.string "developer_access_key"
     t.string "name"
     t.string "developer"
+    t.string "rp_access_key"
     t.date "agreed_on"
     t.date "started_on"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_173904) do
     t.bigint "registered_provider_id"
     t.string "reference_id"
     t.boolean "studio", default: false, null: false
+    t.string "rp_internal_id"
     t.index ["development_id"], name: "index_dwellings_on_development_id"
     t.index ["registered_provider_id"], name: "index_dwellings_on_registered_provider_id"
   end

--- a/spec/features/developer_completion_response_spec.rb
+++ b/spec/features/developer_completion_response_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     expect(@social_dwelling.registered_provider).to eq(@registered_provider2)
 
     @development.reload
-    expect(@development.state).to eq('confirmed_completed')
+    expect(@development.state).to eq('partially_confirmed_completed')
   end
 
   scenario 'successfully but incomplete' do

--- a/spec/features/requesting_developer_and_rp_response_spec.rb
+++ b/spec/features/requesting_developer_and_rp_response_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature 'Requesting a developer completion response', type: :feature do
-  scenario 'when development is unconfirmed_completed and has incomplete dwelling' do
+RSpec.feature 'Requesting responses from RPs and developers', type: :feature do
+  scenario 'when development is unconfirmed_completed' do
     development = create(:development, state: 'unconfirmed_completed')
     login
     click_link 'AP/2019/1234'
@@ -9,11 +9,19 @@ RSpec.feature 'Requesting a developer completion response', type: :feature do
     expect(find_field('developer_response_url').value).to have_content(completion_response_form_development_path(development))
   end
 
+  scenario 'when development is partially_confirmed_completed' do
+    development = create(:development, state: 'partially_confirmed_completed')
+    login
+    click_link 'AP/2019/1234'
+    expect(page).to have_content 'Registered Provider response needed'
+    expect(find_field('rp_response_url').value).to have_content(rp_response_form_development_path(development))
+  end
+
   scenario 'when development is confirmed_completed' do
     create(:development, state: 'confirmed_completed')
     login
     click_link 'AP/2019/1234'
-    expect(page).to have_content 'The developer has responded with the full details for this development.'
+    expect(page).to have_content 'The developer and registered provider have responded with the full details for this development.'
   end
 
   scenario 'when development is not unconfirmed_completed' do

--- a/spec/features/rp_completion_response_spec.rb
+++ b/spec/features/rp_completion_response_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
   before do
     @registered_provider1 = create(:registered_provider, name: 'RPOne')
     @registered_provider2 = create(:registered_provider, name: 'RPTwo')
-    @development = create(:development, state: 'completed')
+    @development = create(:development, state: 'partially_confirmed_completed')
     Dwelling.without_auditing do
       create(:dwelling, development: @development, tenure: 'open')
       @intermediate_dwelling = create(:dwelling, development: @development, tenure: 'intermediate', address: '1 address', registered_provider: @registered_provider1)
@@ -32,6 +32,9 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     @social_dwelling.reload
     expect(@intermediate_dwelling.rp_internal_id).to eq('RP1')
     expect(@social_dwelling.rp_internal_id).to eq('RP2')
+
+    @development.reload
+    expect(@development.state).to eq('confirmed_completed')
   end
 
   scenario 'with wrong access key' do

--- a/spec/features/rp_completion_response_spec.rb
+++ b/spec/features/rp_completion_response_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Developer filling out a completion response', type: :feature do
+  before do
+    @registered_provider1 = create(:registered_provider, name: 'RPOne')
+    @registered_provider2 = create(:registered_provider, name: 'RPTwo')
+    @development = create(:development, state: 'completed')
+    Dwelling.without_auditing do
+      create(:dwelling, development: @development, tenure: 'open')
+      @intermediate_dwelling = create(:dwelling, development: @development, tenure: 'intermediate', address: '1 address', registered_provider: @registered_provider1)
+      @social_dwelling = create(:dwelling, development: @development, tenure: 'social', address: '2 address', registered_provider: @registered_provider1)
+    end
+  end
+
+  scenario 'successfully and completely' do
+    visit rp_response_form_development_path(@development)
+    expect(page).to_not have_content('Open')
+
+    within ".dwelling_#{@intermediate_dwelling.id}" do
+      fill_in 'Your ID', with: 'RP1'
+    end
+
+    within ".dwelling_#{@social_dwelling.id}" do
+      fill_in 'Your ID', with: 'RP2'
+    end
+
+    click_button 'Submit response'
+
+    expect(page).to have_content('Your development information has been submitted')
+
+    @intermediate_dwelling.reload
+    @social_dwelling.reload
+    expect(@intermediate_dwelling.rp_internal_id).to eq('RP1')
+    expect(@social_dwelling.rp_internal_id).to eq('RP2')
+  end
+end

--- a/spec/features/rp_completion_response_spec.rb
+++ b/spec/features/rp_completion_response_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
   end
 
   scenario 'successfully and completely' do
-    visit rp_response_form_development_path(@development)
+    visit rp_response_form_development_path(@development, rpak: @development.rp_access_key)
     expect(page).to_not have_content('Open')
 
     within ".dwelling_#{@intermediate_dwelling.id}" do
@@ -32,5 +32,11 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     @social_dwelling.reload
     expect(@intermediate_dwelling.rp_internal_id).to eq('RP1')
     expect(@social_dwelling.rp_internal_id).to eq('RP2')
+  end
+
+  scenario 'with wrong access key' do
+    expect do
+      visit completion_response_form_development_path(@development, rpak: 'wild-guess')
+    end.to raise_error(ActiveRecord::RecordNotFound)
   end
 end


### PR DESCRIPTION
When a developer has successfully responded to an unconfirmed completed development, it moves into a new state `partially_confirmed`, which shows a new URL to send to the RP, who can confirm they have received the housing, and add their own internal IDs