### PR TITLE
Rename 'unit' in statistics to 'dwellings'

### DIFF
--- a/app/models/dwellings_statistics.rb
+++ b/app/models/dwellings_statistics.rb
@@ -12,7 +12,7 @@ class DwellingsStatistics
     developments.where(filter).sum(:habitable_rooms)
   end
 
-  def unit_count(filter = {})
+  def dwelling_count(filter = {})
     developments.where(filter).count
   end
 
@@ -33,12 +33,12 @@ class DwellingsStatistics
     100 - affordable_habitable_rooms_percentage
   end
 
-  def affordable_units_percentage
-    @affordable_units_percentage ||=
-      ((unit_count(tenure: %w[intermediate social]).to_f / unit_count) * 100).to_i
+  def affordable_dwellings_percentage
+    @affordable_dwellings_percentage ||=
+      ((dwelling_count(tenure: %w[intermediate social]).to_f / dwelling_count) * 100).to_i
   end
 
-  def open_units_percentage
-    100 - affordable_units_percentage
+  def open_dwellings_percentage
+    100 - affordable_dwellings_percentage
   end
 end

--- a/app/views/partials/_statistics.html.haml
+++ b/app/views/partials/_statistics.html.haml
@@ -1,6 +1,6 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    - ['habitable_room', 'unit'].each do |type|
+    - ['habitable_room', 'dwelling'].each do |type|
       %h2.govuk-heading-l By #{type.humanize}
       .govuk-grid-column-two-thirds
         .chart-wrapper{class: 'govuk-!-margin-top-9'}


### PR DESCRIPTION
We're inconsistent in saying 'unit' and 'dwelling'. We probably want to rename everything to unit, but it's much easier for now to be consistent with calling everything dwelling.