### PR TITLE
Stop postgres error causing all builds to fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.5-node-browsers
       - image: circleci/postgres:11
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
     working_directory: ~/repo
 
     steps:


### PR DESCRIPTION
The PostgreSQL Docker Team pushed a [breaking change](https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc) to stop users
running their production databases without a password. This caused the
test build to fail with an error.

Adding the `POSTGRES_HOST_AUTH_METHOD: trust` environment variable to
the postgres container should fix this. A password is not required in
this case as this database will only ever contain test data.