### PR TITLE
Add tenure products to dwellings

### DIFF
--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -157,7 +157,7 @@ class DevelopmentsController < ApplicationController
   end
 
   def completion_response_params
-    params.require(:development).permit(dwellings_attributes: %i[id address uprn registered_provider_id])
+    params.require(:development).permit(dwellings_attributes: %i[id address uprn registered_provider_id tenure_product])
   end
 
   def rp_response_params

--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -7,12 +7,25 @@ class Dwelling < ApplicationRecord
     if: :audit_changes?,
     on: %i[create update destroy],
     comment_required: true,
-    except: %i[address uprn registered_provider_id rp_internal_id]
+    except: %i[address uprn registered_provider_id rp_internal_id tenure_product]
   )
 
   attr_accessor :audit_planning_application_id
 
   TENURES = %w[open social intermediate].freeze
+  TENURE_PRODUCTS = [
+    'Social rent',
+    'Shared ownership',
+    'Shared equity',
+    'London Living Rent',
+    'Community Land Trust',
+    'Discounted market sale',
+    'Starter Home',
+    'Affordable rent',
+    'Discount market rent',
+    'London Affordable Rent',
+    'Build to rent'
+  ].freeze
 
   scope :within_s106, -> { where(tenure: %w[social intermediate]) }
 

--- a/app/views/developments/_dwellings.html.haml
+++ b/app/views/developments/_dwellings.html.haml
@@ -21,6 +21,7 @@
           %th{class: "govuk-table__header", scope: "col"} Address
           %th{class: "govuk-table__header", scope: "col"} UPRN
           %th{class: "govuk-table__header", scope: "col"} Registered provider
+          %th{class: "govuk-table__header", scope: "col"} Tenure Product
           %th{class: "govuk-table__header", scope: "col"} RP Internal ID
         %th{class: "govuk-table__header", scope: "col"} Actions
 
@@ -39,5 +40,6 @@
             %td.govuk-table__cell= dwelling.address.present? ? dwelling.address : 'Not yet supplied'
             %td.govuk-table__cell= dwelling.uprn.present? ? dwelling.uprn : 'Not yet supplied'
             %td.govuk-table__cell= dwelling.registered_provider.present? ? dwelling.registered_provider.name : 'Not yet supplied'
+            %td.govuk-table__cell= dwelling.tenure_product.present? ? dwelling.tenure_product : 'Not yet supplied'
             %td.govuk-table__cell= dwelling.rp_internal_id.present? ? dwelling.rp_internal_id : 'Not yet supplied'
           %td.govuk-table__cell= link_to 'Edit', edit_development_dwelling_path(@development, dwelling), class: "govuk-link", "aria-label": "Edit dwelling #{dwelling.reference_id}"

--- a/app/views/developments/completion_response_form.html.haml
+++ b/app/views/developments/completion_response_form.html.haml
@@ -24,4 +24,5 @@
                 = dwelling_form.input :address, required: 'true'
                 = dwelling_form.input :uprn, required: 'true', label: 'UPRN', input_html: { class: 'govuk-input--width-12' }
                 = dwelling_form.input :registered_provider_id, collection: RegisteredProvider.all, required: 'true', wrapper: :select
+                = dwelling_form.input :tenure_product, collection: Dwelling::TENURE_PRODUCTS, required: 'true', wrapper: :select
         = form.submit 'Submit response', class: 'govuk-button'

--- a/db/migrate/20210127133211_add_tenure_product_to_dwellings.rb
+++ b/db/migrate/20210127133211_add_tenure_product_to_dwellings.rb
@@ -1,0 +1,5 @@
+class AddTenureProductToDwellings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dwellings, :tenure_product, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_102320) do
+ActiveRecord::Schema.define(version: 2021_01_27_133211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_102320) do
     t.boolean "wheelchair_accessible", default: false, null: false
     t.boolean "wheelchair_adaptable", default: false, null: false
     t.string "uprn"
+    t.string "tenure_product"
     t.index ["development_id"], name: "index_dwellings_on_development_id"
     t.index ["registered_provider_id"], name: "index_dwellings_on_registered_provider_id"
   end

--- a/spec/features/developer_completion_response_spec.rb
+++ b/spec/features/developer_completion_response_spec.rb
@@ -20,12 +20,14 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
       fill_in 'Address', with: '1 Newbuild House'
       fill_in 'UPRN', with: 'uprn1'
       select 'RPOne', from: 'Registered provider'
+      select 'London Living Rent', from: 'Tenure product'
     end
 
     within ".dwelling_#{@social_dwelling.id}" do
       fill_in 'Address', with: '2 Newbuild House'
       fill_in 'UPRN', with: 'uprn2'
       select 'RPTwo', from: 'Registered provider'
+      select 'Social rent', from: 'Tenure product'
     end
 
     click_button 'Submit response'
@@ -37,9 +39,11 @@ RSpec.feature 'Developer filling out a completion response', type: :feature do
     expect(@intermediate_dwelling.address).to eq('1 Newbuild House')
     expect(@intermediate_dwelling.uprn).to eq('uprn1')
     expect(@intermediate_dwelling.registered_provider).to eq(@registered_provider1)
+    expect(@intermediate_dwelling.tenure_product).to eq('London Living Rent')
     expect(@social_dwelling.address).to eq('2 Newbuild House')
     expect(@social_dwelling.uprn).to eq('uprn2')
     expect(@social_dwelling.registered_provider).to eq(@registered_provider2)
+    expect(@social_dwelling.tenure_product).to eq('Social rent')
 
     @development.reload
     expect(@development.state).to eq('partially_confirmed_completed')


### PR DESCRIPTION
At completion, the more general "open/social/intermediate" gets more specific to a specific tenure product.

We now ask the developer to let us know what product they used.