### PR TITLE
Update msgpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
-    msgpack (1.4.0)
+    msgpack (1.4.2)
     nio4r (2.5.4)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)


### PR DESCRIPTION
For some reason, msgpack 1.4.0 has been pulled, which breaks the build for the application.

Fix this by updating to 1.4.2