### PR TITLE
Add new tenures and tenure products

### DIFF
--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -12,19 +12,27 @@ class Dwelling < ApplicationRecord
 
   attr_accessor :audit_planning_application_id
 
-  TENURES = %w[open social intermediate].freeze
+  TENURES = %w[open social intermediate other].freeze
   TENURE_PRODUCTS = [
+    'Build for sale',
+    'Build to rent',
     'Social rent',
-    'Shared ownership',
-    'Shared equity',
+    'Affordable rent',
+    'London Affordable Rent',
+    'Social rent equivalent',
+    'Leasehold social',
     'London Living Rent',
     'Community Land Trust',
-    'Discounted market sale',
+    'Discount market sale',
     'Starter Home',
-    'Affordable rent',
+    'Shared equity',
     'Discount market rent',
-    'London Affordable Rent',
-    'Build to rent'
+    'Shared ownership',
+    'London Living Rent Equivalent',
+    'First homes',
+    'Housing for older people',
+    'Supported housing',
+    'Rough sleepers initiative'
   ].freeze
 
   scope :within_s106, -> { where(tenure: %w[social intermediate]) }


### PR DESCRIPTION
This is to more closely match real world data entered by RPs and the data structure in the Affordable Housing Monitoring tool.

## Screenshots

### Adding a new dwelling

"other" has been added to the list

<img width="582" alt="image" src="https://user-images.githubusercontent.com/19826940/144224327-279e63c1-a28b-4363-84f3-8bca6883e3cf.png">

### Filling in the completion form

Many new options have been added e.g. "Housing for older people", "Supported Housing", and "Rough sleepers initiative"

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/19826940/144224339-7451d746-7108-4e91-b78c-16e073e29adf.png">



