### PR TITLE
Update documentation & make project easier to support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew 'rbenv'
+brew 'postgresql' unless system 'which -s psql'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.0.0].
+
+## [Release 000]
+
+The changes in this and previous releases predate this changelog.
+
+[release 000]: https://github.com/dxw/affordable-housing-monitoring/releases/tag/release-000
+[keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Requirements: Ruby 2.6.5, [Postgres](https://postgresapp.com/)
 ```bash
 bundle
 yarn
-rake db:setup
-rails s
+bundle exec rake db:setup
+bundle exec rails s
 ```
 
 ### Docker compose setup
@@ -31,4 +31,4 @@ In either setup, the server will be running on http://localhost:3000, and the de
 
 ## Running the tests
 
-Tests can be run by running `rake`.
+Tests can be run by running `bundle exec rake`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 An alpha project for Southwark for monitoring affordable housing in the borough.
 
-More information can be found at https://www.southwark.gov.uk/innovate/collabrative-project/affordable-housing-monitoring
-
 ## Setting up the project
 
 Project can either be run locally or via Docker Compose

--- a/README.md
+++ b/README.md
@@ -44,3 +44,24 @@ docker-compose up
 ---
 
 In either setup, the server will be running on http://localhost:3000, and the default user is email@example.com with the password of 'password'
+
+## Making changes
+
+When making a change, update the changelog using the Keep a Changelog 1.0.0 format. Pull requests should not be merged before any relevant updates are made.
+
+## Releasing changes
+
+When making a new release, update the changelog in the release pull request.
+
+Pull requests merged into `main` will be deployed to the production environment
+
+To create a production deployment:
+
+1. Create a branch release/xxx
+1. Update changelog for the release
+1. Commit and push
+1. Open PRs from that branch to both main and develop
+1. Get sign off on any other changes in the release, and approval on the PRs
+1. Tag the HEAD of the PR release-xxx and push the tag
+1. Merge both PRs
+1. Watch production and smoke test when deployed

--- a/README.md
+++ b/README.md
@@ -8,14 +8,30 @@ Project can either be run locally or via Docker Compose
 
 ### Local setup
 
-Requirements: Ruby 2.6.5, [Postgres](https://postgresapp.com/)
+Run the setup command. This drops and recreates the database, installs any
+dependencies, runs the DB migrations, and builds the assets:
 
-```bash
-bundle
-yarn
-bundle exec rake db:setup
-bundle exec rails s
 ```
+script/setup
+```
+
+To just update dependencies and database seeds, you can run the bootstrap
+command:
+
+```
+script/bootstrap
+```
+
+## Running the application
+
+```
+script/server
+```
+
+## Running the tests
+
+```
+script/test
 
 ### Docker compose setup
 
@@ -28,7 +44,3 @@ docker-compose up
 ---
 
 In either setup, the server will be running on http://localhost:3000, and the default user is email@example.com with the password of 'password'
-
-## Running the tests
-
-Tests can be run by running `bundle exec rake`.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if ! brew bundle check >/dev/null 2>&1; then
+    echo "==> Installing Homebrew dependencies…"
+      brew bundle install --verbose --no-lock
+fi
+
+if [ -f .ruby-version ]; then
+  eval "$(rbenv init -)"
+
+  if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+    echo "==> Installing Ruby..."
+    rbenv install --skip-existing
+    rbenv rehash
+  fi
+fi
+
+echo "==> Installing Bundler..."
+gem install bundler
+
+echo "==> Installing Ruby dependencies..."
+bundle install
+
+echo "==> Installing JS dependencies..."
+yarn
+
+if brew services | grep postgresql >/dev/null 2>&1 && ! lsof -i tcp:5432 >/dev/null 2>&1; then
+  echo "==> Starting Postgres..."
+  brew services start postgresql
+fi

--- a/script/server
+++ b/script/server
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+bundle exec rails s

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Running bootstrap script..."
+script/bootstrap
+
+echo "==> Dropping any existing project database..."
+dropdb "affordable_housing_monitoring_development" > /dev/null 2>&1 || true
+dropdb "affordable_housing_monitoring_test" > /dev/null 2>&1 || true
+
+echo "==> Setting up DB..."
+bundle exec rake db:setup

--- a/script/test
+++ b/script/test
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+
+set -e
+
+bundle exec rake


### PR DESCRIPTION
Now that we're doing some support tasks on the Alpha codebase, I thought it'd be useful to try and make this project more in line with our usual pattern for doing things.

This PR:
- Adds scripts to rule them all to get set up and run the app locally
- Updates README for a bit more detail
- Adds a CHANGELOG & a release process