### PR TITLE
Release 002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Release 002]
+
+- Bulk import dwellings may have blank habitable rooms
+
 ## [Release 001]
 
 - Dependency updates
@@ -13,6 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 The changes in this and previous releases predate this changelog.
 
+[release 002]: https://github.com/dxw/affordable-housing-monitoring/releases/tag/release-002
 [release 001]: https://github.com/dxw/affordable-housing-monitoring/releases/tag/release-001
 [release 000]: https://github.com/dxw/affordable-housing-monitoring/releases/tag/release-000
 


### PR DESCRIPTION
**NB: we need to merge https://github.com/dxw/affordable-housing-monitoring/pull/222 to "build" (run our tests) using Github Actions rather than via CircleCI which isn't working -- and for which I can't find credentials.**

- Bulk import dwellings may have blank habitable rooms