### PR TITLE
edits Dockerfile to install latest npm and LTS node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,14 @@ MAINTAINER dxw <rails@dxw.com>
 # install base packages
 RUN apt-get update -y -q2 \
   && apt-get upgrade -y -q2 \
-  && apt-get -y -q2 install \
-    nodejs \
   && apt-get -y -q2 clean
+
+# install npm and node LTS
+RUN apt-get update && apt-get install -y -q2 \
+    npm
+RUN npm install npm@latest -g && \
+    npm install n -g && \
+    n lts
 
 RUN YARN_VERSION=1.9.4 \
   set -ex \


### PR DESCRIPTION
- Dockerfile now installs latest npm
- npm then installs LTS node
- the LTS node is to ensure that we have a version >= 12.2.0 which is needed to run certain dependencies in the project (namely normalizeurl)
- previously we were on node 10

FAO reviewer: 
- aware that installing the *latest* npm might not be super safe - do flag if wiser to install named npm version instead, and that version can then install LTS node